### PR TITLE
Fix IO Blocking

### DIFF
--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -85,13 +85,13 @@ def _execute_command(args, print_output, capture_stderr, print_command, *pargs, 
     )
 
     while True:
-        output = stdout_read.readline().decode()
+        output = stdout_read.read(1).decode()
 
         if output == '' and process.poll() is not None:
             break
 
         if print_output and output:
-            print(output, end="")
+            print(output, end="", flush=True)
 
     exit_code = process.poll()
 

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
Apparently `readline()` is a blocking call and will not return until it
reads a whole line. Changing this to `read(1)` means that we read and
print one byte at a time, and we also ignore the io-blocking put in
place when the process waits for input. This fixes the issues with input
prompts showing up late.

Some more discussion of the issue here:
https://stackoverflow.com/questions/375427/non-blocking-read-on-a-subprocess-pipe-in-python

Also added flush=True to the print command to force flushing of the
buffer.