### PR TITLE
Fix bug in plan check when directory path is a prefix of another

### DIFF
--- a/bin/plan_check
+++ b/bin/plan_check
@@ -258,6 +258,8 @@ def get_modified_subdirectories(root_directory: str) -> Tuple[List[str], List[st
     directories_to_check_under_root = {
         directory
         for directory in directories_to_check
+        # if the longest common path of two directories is one of the directories
+        # then the other directory must be a child of the first
         if os.path.commonpath([root_directory, directory]) == root_directory and os.path.exists(directory)
     }
 

--- a/bin/plan_check
+++ b/bin/plan_check
@@ -255,20 +255,20 @@ def get_modified_subdirectories(root_directory: str) -> Tuple[List[str], List[st
     # filter out any directories that aren't under our root.
     # We may have got some while following symlinks and module links
     # some directories may also not exist if they were deleted. can't run plan on them
-    directories_to_check = {
+    directories_to_check_under_root = {
         directory
         for directory in directories_to_check
-        if directory.startswith(root_directory) and os.path.exists(directory)
+        if os.path.commonpath([root_directory, directory]) == root_directory and os.path.exists(directory)
     }
 
     # group directories into regular and symlink paths so downstream code can treat them differently
     regular_directories = [
-        directory for directory in directories_to_check
+        directory for directory in directories_to_check_under_root
         if not os.path.islink(directory)
     ]
 
     symlinked_directories = [
-        directory for directory in directories_to_check
+        directory for directory in directories_to_check_under_root
         if os.path.islink(directory)
     ]
 

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.4.9"
+__version__ = "0.4.10"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
The plan check would sometimes pick up the wrong directories when using `--modified-only` if a modified directory path was a substring of the root directory even if that directory was not a child. For example:

root directory: /foo/bar
modified directory: /foo/bar2

in the above case, `/foo/bar2` is not a child of the root directory so we shouldn't run plan on it even if some files under it have been modified. `/foo/bar2` is a substring of `/foo/bar` though and this would cause the plan_check to run plan on that directory incorrectly