### PR TITLE
Optionally Allow Less Printing for tf_apply

### DIFF
--- a/bin/tf_apply
+++ b/bin/tf_apply
@@ -3,7 +3,7 @@
 Terraform Wrapper Apply
 
 Usage:
-    tf_apply --pipeline=PIPELINE [--operation=OPERATION] [--parallel-jobs=NUM_JOBS] [--debug]
+    tf_apply --pipeline=PIPELINE [--operation=OPERATION] [--parallel-jobs=NUM_JOBS] [--debug] [--print-only-changes]
     tf_apply --version
 
 Options:
@@ -16,6 +16,7 @@ Options:
     -j NUM_JOBS --parallel-jobs=NUM_JOBS        The number of Terraform operations to run in parallel.
                                                 [default: 4].
     -v,--debug                                  Turns on debug logging.
+    --print-only-changes                        Only print output for directories that have changes.
     --version                                   Display the current version of Terraform Wrapper.
 """
 
@@ -42,7 +43,11 @@ def handler():
 
     pipeline = Pipeline(operation, pipeline_path=pipeline_file)
 
-    pipeline.execute(num_parallel=num_parallel, debug=args['--debug'])
+    pipeline.execute(
+        num_parallel=num_parallel,
+        debug=args['--debug'],
+        print_only_changes=args['--print-only-changes'],
+    )
 
 
 if __name__ == "__main__":

--- a/package-lock.json
+++ b/package-lock.json
@@ -724,7 +724,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -748,13 +749,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -771,19 +774,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -914,7 +920,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -928,6 +935,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -944,6 +952,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -952,13 +961,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -979,6 +990,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1067,7 +1079,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1081,6 +1094,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1176,7 +1190,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1218,6 +1233,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1239,6 +1255,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1287,13 +1304,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_pipeline.py
+++ b/test/unit/test_pipeline.py
@@ -20,7 +20,7 @@ class TestPipeline(TestCase):
     @patch('terrawrap.models.pipeline.PipelineEntry')
     def test_execute(self, pipeline_entry_class):
         """Test that executing a pipeline will call init and then the command"""
-        pipeline_entry_class.return_value.execute.return_value = (0, ['Success'])
+        pipeline_entry_class.return_value.execute.return_value = (0, ['Success'], True)
 
         pipeline = Pipeline('plan', 'pipelines/test.csv')
 
@@ -28,5 +28,5 @@ class TestPipeline(TestCase):
 
         self.assertEqual(
             pipeline_entry_class.return_value.execute.mock_calls,
-            [call('init', debug=False), call('plan', debug=False)]
+            [call('plan', debug=False)]
         )

--- a/test/unit/test_pipeline_entry.py
+++ b/test/unit/test_pipeline_entry.py
@@ -15,10 +15,11 @@ class TestPipelineEntry(TestCase):
         exec_command.side_effect = [(0, ['Success'])]
 
         entry = PipelineEntry('/var', [])
-        exit_code, stdout = entry.execute('plan')
+        exit_code, stdout, changes_detected = entry.execute('plan')
 
         self.assertEqual(exit_code, 0)
-        self.assertEqual(stdout, ['Success'])
+        self.assertEqual(stdout, ['Success', '\n'])
+        self.assertEqual(changes_detected, False)
 
     @patch('terrawrap.models.pipeline_entry.execute_command')
     def test_execute_fail(self, exec_command):
@@ -26,7 +27,39 @@ class TestPipelineEntry(TestCase):
         exec_command.side_effect = [(1, ['Fail'])]
 
         entry = PipelineEntry('/var', [])
-        exit_code, stdout = entry.execute('plan')
+        exit_code, stdout, changes_detected = entry.execute('plan')
 
         self.assertEqual(exit_code, 1)
         self.assertEqual(stdout, ['Fail'])
+        self.assertEqual(changes_detected, True)
+
+    @patch('terrawrap.models.pipeline_entry.execute_command')
+    def test_execute_apply_changes(self, exec_command):
+        """Test executing apply with changes"""
+        exec_command.side_effect = [
+            (0, ['Success']),
+            (2, ['Something changed']),
+            (0, ['Success']),
+        ]
+
+        entry = PipelineEntry('/var', [])
+        exit_code, stdout, changes_detected = entry.execute('apply')
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout, ['Success', '\n', 'Something changed', '\n', 'Success'])
+        self.assertEqual(changes_detected, True)
+
+    @patch('terrawrap.models.pipeline_entry.execute_command')
+    def test_execute_apply_no_changes(self, exec_command):
+        """Test executing apply with no changes"""
+        exec_command.side_effect = [
+            (0, ['Success']),
+            (0, ['Nothing changed']),
+        ]
+
+        entry = PipelineEntry('/var', [])
+        exit_code, stdout, changes_detected = entry.execute('apply')
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout, ['Success', '\n', 'Nothing changed'])
+        self.assertEqual(changes_detected, False)


### PR DESCRIPTION
Added a `--print-only-changes` option to tf_apply, that will change the
behavior of tf_apply such that it only prints Terraform output for
directories that actually changed.

Additionally, tf_apply will now not apply a directory if the plan comes
back clean for it.

Additionally, tf_apply will now run init and the desired command in one
operation, which should make applies overall faster and reduce some
needless printing that was going on.