### PR TITLE
Add depends on field to wrapper config obj

### DIFF
--- a/terrawrap/models/wrapper_config.py
+++ b/terrawrap/models/wrapper_config.py
@@ -3,7 +3,7 @@
 # pylint: disable=missing-docstring
 
 from enum import Enum
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 import jsons
 
@@ -72,7 +72,8 @@ class WrapperConfig:
             backend_check: bool = True,
             plan_check: bool = True,
             envvars: Dict[str, AbstractEnvVarConfig] = None,
-            backends: BackendsConfig = None
+            backends: BackendsConfig = None,
+            depends_on: List[str] = None
     ):
         self.configure_backend = configure_backend
         self.pipeline_check = pipeline_check
@@ -80,3 +81,4 @@ class WrapperConfig:
         self.plan_check = plan_check
         self.envvars = envvars or {}
         self.backends = backends
+        self.depends_on = depends_on

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.5.11"
+__version__ = "0.5.12"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
This is needed so checks won't fail on PRs. Pulled out to allow for testing