### PR TITLE
Gracefully handle being unable to read the lock id from error messages

### DIFF
--- a/bin/tf
+++ b/bin/tf
@@ -120,7 +120,11 @@ def tf_unlock(error: str, path: str, lock_timeout: timedelta) -> bool:
     :param lock_timeout: Time to wait before running unlock command (timedelta object)
     :return: True if unlock command runs successfully, otherwise False
     """
-    lock_id = re.search(r'[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}', error).group()
+    match = re.search(r'[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}', error)
+    if not match:
+        return False
+
+    lock_id = match.group()
     # Creation time example: '2018-10-10 15:23:09.715308766 +0000 UTC'
     # strptime can handle microseconds, not nanoseconds
     # utcnow object does not have offset and timezone name

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.5.13"
+__version__ = "0.5.14"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
Fixes this error when getting a state exception from terraform and being unable to parse out the lock id from the error message

```
Traceback (most recent call last):
  File "/Users/aoskotsky/.virtualenvs/python3/bin/tf", line 257, in <module>
    handler()
  File "/Users/aoskotsky/.virtualenvs/python3/bin/tf", line 252, in handler
    additional_envvars=additional_envvars
  File "/Users/aoskotsky/.virtualenvs/python3/bin/tf", line 106, in exec_tf_command
    if tf_unlock(error, path, LOCK_TIMEOUT):
  File "/Users/aoskotsky/.virtualenvs/python3/bin/tf", line 123, in tf_unlock
    lock_id = re.search(r'[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}', error).group()
AttributeError: 'NoneType' object has no attribute 'group'
```