### PR TITLE
BugFix: DynamoDB Unlock

### DIFF
--- a/bin/tf
+++ b/bin/tf
@@ -36,7 +36,8 @@ from terrawrap.utils.config import (
     parse_variable_files,
     find_wrapper_config_files,
     resolve_envvars,
-    parse_backend_config_for_dir
+    parse_backend_config_for_dir,
+    calc_repo_path,
 )
 from terrawrap.utils.dynamodb import DynamoDB
 from terrawrap.utils.path import get_absolute_path
@@ -163,7 +164,10 @@ def update_digest(error: str, path: str, variables: Dict[str, str]) -> bool:
     :return: True if digest is updated, otherwise False
     """
     dynamodb = DynamoDB(region=variables['region'])
-    digest = re.search(r'[\da-f]{32}', error).group()
+    try:
+        digest = re.search(r'[\da-f]{32}', error).group()
+    except AttributeError:
+        digest = ""
 
     default_terraform_bucket = "{region}--mclass--terraform--{account_short_name}".format(
         region=variables.get('region'),
@@ -174,15 +178,22 @@ def update_digest(error: str, path: str, variables: Dict[str, str]) -> bool:
 
     lock_id = '{bucket_name}/{path}.tfstate-md5'.format(
         bucket_name=terraform_bucket,
-        path=re.sub('.*/terraform-config', 'terraform-config', path)
+        path=calc_repo_path(path=path),
     )
-    response = dynamodb.upsert_item(
-        table_name='terraform-locking',
-        primary_key_name='LockID',
-        primary_key_value=lock_id,
-        attribute_name='Digest',
-        attribute_value=digest
-    )
+    if digest:
+        response = dynamodb.upsert_item(
+            table_name='terraform-locking',
+            primary_key_name='LockID',
+            primary_key_value=lock_id,
+            attribute_name='Digest',
+            attribute_value=digest
+        )
+    else:
+        response = dynamodb.delete_item(
+            table_name='terraform-locking',
+            primary_key_name='LockID',
+            primary_key_value=lock_id,
+        )
     if response['ResponseMetadata']['HTTPStatusCode'] == 200:
         return True
 

--- a/bin/tf
+++ b/bin/tf
@@ -37,10 +37,9 @@ from terrawrap.utils.config import (
     find_wrapper_config_files,
     resolve_envvars,
     parse_backend_config_for_dir,
-    calc_repo_path,
 )
 from terrawrap.utils.dynamodb import DynamoDB
-from terrawrap.utils.path import get_absolute_path
+from terrawrap.utils.path import get_absolute_path, calc_repo_path
 
 LOCK_TIMEOUT = timedelta(minutes=60)
 MAX_COUNT = 5

--- a/terrawrap/models/graph.py
+++ b/terrawrap/models/graph.py
@@ -1,6 +1,6 @@
 """Module containing the ApplyGraph class"""
 import concurrent.futures
-from typing import List
+from typing import List, Dict, Set
 
 import networkx
 
@@ -20,11 +20,11 @@ class ApplyGraph:
         """
         self.command = command
         self.graph = graph
-        self.graph_dict = {}
+        self.graph_dict: Dict[str, GraphEntry] = {}
         self.post_graph = post_graph
         self.prefix = prefix
-        self.not_applied = set()
-        self.failures = []
+        self.not_applied: Set[str] = set()
+        self.failures: List[str] = []
 
     # pylint: disable=too-many-locals
     def execute_graph(self, num_parallel: int = 4, debug: bool = False, print_only_changes: bool = False):
@@ -110,7 +110,7 @@ class ApplyGraph:
         for future in concurrent.futures.as_completed(futures_to_paths):
 
             path = futures_to_paths[future]
-            if self.graph_dict.get(path).state != "no-op":
+            if self.graph_dict[path].state != "no-op":
                 exit_code, stdout, changes_detected = future.result()
 
                 if print_only_changes and not changes_detected:
@@ -152,7 +152,7 @@ class ApplyGraph:
             for future in concurrent.futures.as_completed(futures_to_paths):
 
                 path = futures_to_paths[future]
-                if self.graph_dict.get(path).state != "no-op":
+                if self.graph_dict[path].state != "no-op":
 
                     exit_code, stdout, changes_detected = future.result()
 
@@ -171,7 +171,7 @@ class ApplyGraph:
                 self.not_applied.add(node)
             else:
                 if item.state == "no-op":
-                    self.not_applied.add(item)
+                    self.not_applied.add(item.path)
 
     def _can_be_applied(self, entry: GraphEntry):
         """

--- a/terrawrap/utils/config.py
+++ b/terrawrap/utils/config.py
@@ -144,6 +144,8 @@ def walk_and_graph_directory(starting_dir: str, config_dict) -> Tuple[networkx.D
                 wrapper_config_obj = create_wrapper_config_obj(root, wrapper_file)
                 if not wrapper_config_obj.config:
                     continue
+                if not wrapper_config_obj.pipeline_check:
+                    continue
                 if wrapper_config_obj.depends_on is None:
                     post_graph_runs.append(root)
                     continue

--- a/terrawrap/utils/config.py
+++ b/terrawrap/utils/config.py
@@ -261,14 +261,7 @@ def calc_backend_config(
 
     backend_config = ['-reconfigure']
     options: Dict[str, str] = {}
-
-    byte_output = subprocess.check_output(["git", "remote", "show", "origin", "-n"], cwd=path)
-    output = byte_output.decode("utf-8", errors="replace")
-    match = re.search(GIT_REPO_REGEX, output)
-    if match:
-        repo_name = match.group(1)
-    else:
-        raise RuntimeError("Could not determine git repo name, are we in a git repo?")
+    repo_path = calc_repo_path(path=path)
 
     # for backwards compatibility, include the default s3 backend options we used to automatically include
     if existing_backend_config.s3 is not None:
@@ -280,7 +273,7 @@ def calc_backend_config(
         options = {
             'dynamodb_table': variables.get('terraform_lock_table', 'terraform-locking'),
             'encrypt': 'true',
-            'key': '%s/%s.tfstate' % (repo_name, path[path.index("/config") + 1:]),
+            'key': '%s.tfstate' % repo_path,
             'region': variables.get('region', ''),
             'bucket': variables.get('terraform_state_bucket', terraform_bucket),
             'skip_region_validation': 'true',
@@ -293,13 +286,31 @@ def calc_backend_config(
         if existing_backend_config.gcs is not None and wrapper_config.backends.gcs is not None:
             # convert the object into a dict so we can append each field to the backend config dynamically
             wrapper_options = vars(wrapper_config.backends.gcs)
-            wrapper_options['prefix'] = '%s/%s' % (repo_name, path[path.index("/config") + 1:])
+            wrapper_options['prefix'] = repo_path
         if existing_backend_config.s3 is not None and wrapper_config.backends.s3 is not None:
             wrapper_options = vars(wrapper_config.backends.s3)
         options.update({key: value for key, value in wrapper_options.items() if value is not None})
 
     backend_config.extend(['-backend-config=%s=%s' % (key, value) for key, value in options.items()])
     return backend_config
+
+
+def calc_repo_path(path: str) -> str:
+    """
+    Convenience function for taking an absolute path to a TF directory and returning the path to that
+    directory relative to the repo.
+    :param path: The absolute path to a TF directory.
+    :return: New path to the TF directory
+    """
+    byte_output = subprocess.check_output(["git", "remote", "show", "origin", "-n"], cwd=path)
+    output = byte_output.decode("utf-8", errors="replace")
+    match = re.search(GIT_REPO_REGEX, output)
+    if match:
+        repo_name = match.group(1)
+    else:
+        raise RuntimeError("Could not determine git repo name, are we in a git repo?")
+
+    return '%s/%s' % (repo_name, path[path.index("/config") + 1:])
 
 
 def parse_variable_files(variable_files: List[str]) -> Dict[str, str]:

--- a/terrawrap/utils/config.py
+++ b/terrawrap/utils/config.py
@@ -1,8 +1,6 @@
 """Holds config utilities"""
 import os
-import re
 import sys
-import subprocess
 from typing import Dict, List, Optional, Tuple
 import networkx
 
@@ -19,9 +17,8 @@ from terrawrap.models.wrapper_config import (
     BackendsConfig
 )
 from terrawrap.utils.collection_utils import update
-from terrawrap.utils.path import get_absolute_path
+from terrawrap.utils.path import get_absolute_path, calc_repo_path
 
-GIT_REPO_REGEX = r"URL.*/([\w-]*)(?:\.git)?"
 DEFAULT_REGION = 'us-west-2'
 SSM_ENVVAR_CACHE = SSMParameterGroup(max_age=600)
 
@@ -293,24 +290,6 @@ def calc_backend_config(
 
     backend_config.extend(['-backend-config=%s=%s' % (key, value) for key, value in options.items()])
     return backend_config
-
-
-def calc_repo_path(path: str) -> str:
-    """
-    Convenience function for taking an absolute path to a TF directory and returning the path to that
-    directory relative to the repo.
-    :param path: The absolute path to a TF directory.
-    :return: New path to the TF directory
-    """
-    byte_output = subprocess.check_output(["git", "remote", "show", "origin", "-n"], cwd=path)
-    output = byte_output.decode("utf-8", errors="replace")
-    match = re.search(GIT_REPO_REGEX, output)
-    if match:
-        repo_name = match.group(1)
-    else:
-        raise RuntimeError("Could not determine git repo name, are we in a git repo?")
-
-    return '%s/%s' % (repo_name, path[path.index("/config") + 1:])
 
 
 def parse_variable_files(variable_files: List[str]) -> Dict[str, str]:

--- a/terrawrap/utils/dynamodb.py
+++ b/terrawrap/utils/dynamodb.py
@@ -2,6 +2,7 @@
 from typing import Any, Dict
 
 import boto3
+from amplify_aws_utils.resource_helper import throttled_call
 
 
 class DynamoDB:
@@ -32,9 +33,31 @@ class DynamoDB:
         expression_attribute_values = {':d': {'S': attribute_value}}
         update_expression = 'SET {} = :d'.format(attribute_name)
 
-        return self.client.update_item(
+        return throttled_call(
+            self.client.update_item,
             TableName=table_name,
             Key=key,
             ExpressionAttributeValues=expression_attribute_values,
             UpdateExpression=update_expression
+        )
+
+    def delete_item(
+            self,
+            table_name: str,
+            primary_key_name: str,
+            primary_key_value: str,
+    ):
+        """
+        Convenience function for deleting an item from a DynamoDB table with a specific primary key value.
+        :param table_name: DynamoDB table name
+        :param primary_key_name: Table's primary key name
+        :param primary_key_value: Table's primary key value
+        :return: response
+        """
+        key = {primary_key_name: {'S': primary_key_value}}
+
+        return throttled_call(
+            self.client.delete_item,
+            TableName=table_name,
+            Key=key,
         )

--- a/terrawrap/utils/graph.py
+++ b/terrawrap/utils/graph.py
@@ -109,7 +109,7 @@ def visualize(dependencies: List[List[str]]):
         depth += 1
 
 
-def find_symlink_directories(graph: networkx.DiGraph) -> List[str]:
+def find_symlink_directories(graph: networkx.DiGraph) -> List[Path]:
     """
     Finds all symlink directories in a given graph
     :param graph: The graph to find symlinks in

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.5.19"
+__version__ = "0.5.20"
 __git_hash__ = "GIT_HASH"

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.5.18"
+__version__ = "0.5.19"
 __git_hash__ = "GIT_HASH"

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.5.17"
+__version__ = "0.5.18"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_apply_graph.py
+++ b/test/unit/test_apply_graph.py
@@ -73,7 +73,10 @@ class TestApplyGraph(TestCase):
             graph_entry_class.return_value.execute.mock_calls,
             []
         )
-        self.assertTrue(len(graph.not_applied) == 2)
+        self.assertEqual(
+            graph.not_applied,
+            {graph_entry_class.return_value.path}
+        )
 
     @patch('terrawrap.models.graph.GraphEntry')
     def test_runtime_errors(self, graph_entry_class):


### PR DESCRIPTION
Two fixes here... The DynamoDB unlock functionality would fail when
called from repos that are not called terraform-config, so broke out the
function for figuring out the backend state path so it can be reused.

I also added additional error handling where we delete the lock if the
state file is deleted.