### PR TITLE
BugFix: Correctly Handle Destroy Operation in tf_apply

### DIFF
--- a/terrawrap/models/pipeline_entry.py
+++ b/terrawrap/models/pipeline_entry.py
@@ -93,6 +93,9 @@ class PipelineEntry:
 
             operation_args += [plan_file_name]
 
+        if operation in ["plan"]:
+            operation_args += ["--detailed-exitcode"]
+
         operation_exit_code, operation_stdout = execute_command(
             operation_args,
             print_output=False,
@@ -102,8 +105,16 @@ class PipelineEntry:
 
         output += ["\n"] + operation_stdout
 
+        changes_detected = True
+        if operation in ["plan"]:
+            if operation_exit_code == 2:
+                # Set exit code to 0 so the command doesn't fail out
+                operation_exit_code = 0
+            elif operation_exit_code != 2:
+                changes_detected = False
+
         return (
             operation_exit_code,
             output,
-            True,
+            changes_detected,
         )

--- a/terrawrap/models/pipeline_entry.py
+++ b/terrawrap/models/pipeline_entry.py
@@ -63,7 +63,7 @@ class PipelineEntry:
         if operation in ["apply", "destroy"]:
             operation_args += ["-auto-approve"]
 
-        init_exit_code, init_stdout = execute_command(
+        init_exit_code, output = execute_command(
             init_args,
             print_output=False,
             capture_stderr=True,
@@ -71,8 +71,9 @@ class PipelineEntry:
         )
 
         if init_exit_code != 0:
-            return init_exit_code, init_stdout, True
+            return init_exit_code, output, True
 
+        # We need to plan first before we apply so we can actually see a plan... Thanks Hashicorp
         if operation in ["apply"]:
             plan_exit_code, plan_stdout = execute_command(
                 plan_args,
@@ -80,19 +81,17 @@ class PipelineEntry:
                 capture_stderr=True,
                 env=command_env
             )
+
+            output += ["\n"] + plan_stdout
+
+            if plan_exit_code != 2:
+                return (
+                    plan_exit_code,
+                    output,
+                    False,
+                )
+
             operation_args += [plan_file_name]
-        else:
-            plan_exit_code = 0
-            plan_stdout = []
-
-        changes_detected = plan_exit_code != 0
-
-        if plan_exit_code != 2:
-            return (
-                plan_exit_code,
-                init_stdout + ["\n"] + plan_stdout,
-                changes_detected,
-            )
 
         operation_exit_code, operation_stdout = execute_command(
             operation_args,
@@ -101,8 +100,10 @@ class PipelineEntry:
             env=command_env
         )
 
+        output += ["\n"] + operation_stdout
+
         return (
             operation_exit_code,
-            init_stdout + ["\n"] + plan_stdout + ["\n"] + operation_stdout,
-            changes_detected,
+            output,
+            True,
         )

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.5.23"
+__version__ = "0.5.24"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_pipeline_entry.py
+++ b/test/unit/test_pipeline_entry.py
@@ -12,13 +12,16 @@ class TestPipelineEntry(TestCase):
     @patch('terrawrap.models.pipeline_entry.execute_command')
     def test_execute(self, exec_command):
         """Test executing a command successfully"""
-        exec_command.side_effect = [(0, ['Success'])]
+        exec_command.side_effect = [
+            (0, ['Success']),  # init
+            (0, ['Success']),  # plan with no changes
+        ]
 
         entry = PipelineEntry('/var', [])
         exit_code, stdout, changes_detected = entry.execute('plan')
 
         self.assertEqual(exit_code, 0)
-        self.assertEqual(stdout, ['Success', '\n'])
+        self.assertEqual(stdout, ['Success', '\n', 'Success'])
         self.assertEqual(changes_detected, False)
 
     @patch('terrawrap.models.pipeline_entry.execute_command')


### PR DESCRIPTION
Simplify the handling for the plan operation so that it only happens
for apply operation and doesn't block destroy from running.