### PR TITLE
Update plan_check to Print IAM and Error Directories

### DIFF
--- a/bin/plan_check
+++ b/bin/plan_check
@@ -176,7 +176,7 @@ def execute_init_and_plan(
         skip_iam: bool,
         print_diff: bool,
         with_colors: bool
-) -> WrapperExitCode:
+) -> Tuple[List[str], List[str]]:
     """
     Execute functions concurrently
     :param regular_directories: Non symlinked directories to be processed in parallel
@@ -184,15 +184,19 @@ def execute_init_and_plan(
     :param skip_iam: A boolean to skip iam changes check
     :param print_diff: A boolean to control printing diffs for changes
     :param with_colors: A boolean to control printing diffs with ansi colors
-    :return: exit code
+    :return: Tuple of two lists, the first list is of directories with terraform failures, the second is of
+    directories with IAM failures.
     """
-    worst_exit_code = WrapperExitCode.SUCCESS
     # Lookup everyone's environment variables at once so that we get the benefit of Parameter Store calls
     # being cached.
     directory_to_envvars = {
         directory: resolve_envvars(parse_wrapper_configs(find_wrapper_config_files(directory)).envvars)
         for directory in regular_directories + symlinked_directories
     }
+
+    # Track directories with IAM issues or errors.
+    directories_with_iam_changes = []
+    directories_with_errors = []
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
         future_exec = {}
@@ -210,16 +214,21 @@ def execute_init_and_plan(
 
         for future in concurrent.futures.as_completed(future_exec):
             exit_code = future.result()
-            if exit_code != WrapperExitCode.SUCCESS:
-                worst_exit_code = max(worst_exit_code, exit_code, key=attrgetter('value'))
+            directory = future_exec[future]
+            if exit_code == WrapperExitCode.IAM_CHANGES:
+                directories_with_iam_changes.append(directory)
+            if exit_code == WrapperExitCode.TERRAFORM_FAILURE:
+                directories_with_errors.append(directory)
 
     for directory in symlinked_directories:
         envvars = directory_to_envvars[directory]
         exit_code = init_and_plan_directory(directory, skip_iam, print_diff, with_colors, envvars)
-        if exit_code != WrapperExitCode.SUCCESS:
-            worst_exit_code = max(worst_exit_code, exit_code, key=attrgetter('value'))
+        if exit_code == WrapperExitCode.IAM_CHANGES:
+            directories_with_iam_changes.append(directory)
+        if exit_code == WrapperExitCode.TERRAFORM_FAILURE:
+            directories_with_errors.append(directory)
 
-    return worst_exit_code
+    return directories_with_errors, directories_with_iam_changes
 
 
 def get_modified_subdirectories(root_directory: str) -> Tuple[List[str], List[str]]:
@@ -333,19 +342,25 @@ def main():
         % (regular_directories, symlinked_directories)
     )
 
-    exit_code = execute_init_and_plan(
+    failing_directories, iam_directories = execute_init_and_plan(
         regular_directories, symlinked_directories, skip_iam, print_diff, with_colors
     )
 
-    if exit_code == WrapperExitCode.TERRAFORM_FAILURE:
+    if failing_directories:
         print("General Terraform failures detected. Check the output above and please resolve any issues.")
+        print("Directories with Terraform failures:")
+        for directory in failing_directories:
+            print("\t%s" % directory)
 
-    if exit_code == WrapperExitCode.IAM_CHANGES:
+    if iam_directories:
         print(
-            "IAM changes have been detected. If this is intended, please contact the devops team to merge."
+            "\nIAM changes have been detected. If this is intended, please contact the DevOps team to merge."
         )
+        print("Directories with IAM changes:")
+        for directory in iam_directories:
+            print("\t%s" % directory)
 
-    exit(exit_code.value)
+    exit(1 if iam_directories or failing_directories else 0)
 
 
 if __name__ == '__main__':

--- a/terrawrap/utils/plugin_download.py
+++ b/terrawrap/utils/plugin_download.py
@@ -118,8 +118,8 @@ class PluginDownload:
                 return None
 
             return response.content, response.headers.get('etag')
-        except requests.HTTPError:
-            raise FileDownloadFailed()
+        except requests.HTTPError as exception:
+            raise FileDownloadFailed() from exception
 
     def _get_s3_content(self, url: str, etag: Optional[str]) -> Optional[Tuple[bytes, Optional[str]]]:
         """Download a file from S3 using the AWS SDK"""

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.6.8"
+__version__ = "0.6.9"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
This should update the plan_check command to print a summary of all directories with IAM changes and Terraform failures at the end of the command.

The new output will look something like:
```
General Terraform failures detected. Check the output above and please resolve any issues.
Directories with Terraform failures:
	/home/jconstance/workspace/terraform-config/config/aws/amplify-devops-testing/general/astrotools/db_refresh

IAM changes have been detected. If this is intended, please contact the DevOps team to merge.
Directories with IAM changes:
	/home/jconstance/workspace/terraform-config/config/aws/amplify-devops-testing/general/iam
```