### PR TITLE
BugFix: Bump python-hcl2 Version

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -8,7 +8,7 @@ pyyaml>=3.13,<4
 ssm-cache>=2.7,<3
 # lock jsons version because it causes python3.6 unit tests to fail
 jsons==0.10.2
-python-hcl2>=0.2.6,<0.3.0
+python-hcl2>=2,<3
 # Packaging does not obey semver
 packaging==19.1
 diskcache>=4.0.0,<5

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.6.10"
+__version__ = "0.6.11"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
This fixes some parsing errors with the latest version of Terraform.