### PR TITLE
Terrawrap shouldn't init env vars unless it execute the directory

### DIFF
--- a/terrawrap/models/graph_entry.py
+++ b/terrawrap/models/graph_entry.py
@@ -5,7 +5,11 @@ import tempfile
 from typing import List, Tuple
 
 from terrawrap.utils.cli import execute_command
-from terrawrap.utils.config import find_wrapper_config_files, parse_wrapper_configs, resolve_envvars
+from terrawrap.utils.config import (
+    find_wrapper_config_files,
+    parse_wrapper_configs,
+    resolve_envvars
+)
 from terrawrap.utils.path import get_absolute_path
 
 logger = logging.getLogger(__name__)
@@ -20,7 +24,6 @@ class GraphEntry:
         :param variables: Any additional variables to set alongside the Terraform command.
         """
         self.path = get_absolute_path(path=path)
-
         self.variables = variables
         self.state = "Pending"
 

--- a/terrawrap/models/graph_entry.py
+++ b/terrawrap/models/graph_entry.py
@@ -8,7 +8,7 @@ from terrawrap.utils.cli import execute_command
 from terrawrap.utils.config import (
     find_wrapper_config_files,
     parse_wrapper_configs,
-    resolve_envvars
+    resolve_envvars,
 )
 from terrawrap.utils.path import get_absolute_path
 
@@ -34,7 +34,9 @@ class GraphEntry:
         self.state = "no-op"
 
     # pylint: disable=too-many-locals
-    def execute(self, operation: str, debug: bool = False) -> Tuple[int, List[str], bool]:
+    def execute(
+            self, operation: str, debug: bool = False
+    ) -> Tuple[int, List[str], bool]:
         """
         Function for executing this Graph Entry.
         :param operation: The Terraform operation to execute. IE: apply, plan
@@ -76,20 +78,14 @@ class GraphEntry:
             operation_args += ["-auto-approve"]
 
         init_exit_code, init_stdout = execute_command(
-            init_args,
-            print_output=False,
-            capture_stderr=True,
-            env=command_env,
+            init_args, print_output=False, capture_stderr=True, env=command_env
         )
         if init_exit_code != 0:
             self.state = "Failed"
             return init_exit_code, init_stdout, True
         if operation in ["apply"]:
             plan_exit_code, plan_stdout = execute_command(
-                plan_args,
-                print_output=False,
-                capture_stderr=True,
-                env=command_env
+                plan_args, print_output=False, capture_stderr=True, env=command_env
             )
             operation_args += [plan_file_name]
         else:
@@ -110,10 +106,7 @@ class GraphEntry:
             )
 
         operation_exit_code, operation_stdout = execute_command(
-            operation_args,
-            print_output=False,
-            capture_stderr=True,
-            env=command_env
+            operation_args, print_output=False, capture_stderr=True, env=command_env
         )
 
         if operation_exit_code == 0:

--- a/terrawrap/models/graph_entry.py
+++ b/terrawrap/models/graph_entry.py
@@ -35,7 +35,7 @@ class GraphEntry:
 
     # pylint: disable=too-many-locals
     def execute(
-            self, operation: str, debug: bool = False
+        self, operation: str, debug: bool = False
     ) -> Tuple[int, List[str], bool]:
         """
         Function for executing this Graph Entry.
@@ -54,24 +54,18 @@ class GraphEntry:
             command_env["TF_LOG"] = "DEBUG"
 
         # pylint: disable=unused-variable
-        plan_file, plan_file_name = tempfile.mkstemp(
-            suffix=".tfplan"
-        )
+        plan_file, plan_file_name = tempfile.mkstemp(suffix=".tfplan")
 
         # We're using --no-resolve-envvars here because we've already resolved the environment variables in
         # the constructor. We are then passing in those environment variables explicitly in the
         # execute_command call below.
-        base_args = [
-            "tf",
-            "--no-resolve-envvars",
-            self.path
-        ]
+        base_args = ["tf", "--no-resolve-envvars", self.path]
         init_args = base_args + ["init"] + self.variables
-        plan_args = base_args + [
-            "plan",
-            "-detailed-exitcode",
-            "-out=%s" % plan_file_name
-        ] + self.variables
+        plan_args = (
+            base_args
+            + ["plan", "-detailed-exitcode", "-out=%s" % plan_file_name]
+            + self.variables
+        )
         operation_args = base_args + [operation] + self.variables
 
         if operation in ["apply", "destroy"]:

--- a/terrawrap/models/graph_entry.py
+++ b/terrawrap/models/graph_entry.py
@@ -20,9 +20,7 @@ class GraphEntry:
         :param variables: Any additional variables to set alongside the Terraform command.
         """
         self.path = get_absolute_path(path=path)
-        wrapper_config_files = find_wrapper_config_files(self.path)
-        wrapper_config = parse_wrapper_configs(wrapper_config_files)
-        self.envvars = resolve_envvars(wrapper_config.envvars)
+
         self.variables = variables
         self.state = "Pending"
 
@@ -42,7 +40,10 @@ class GraphEntry:
         """
         self.state = "Executing"
         command_env = os.environ.copy()
-        command_env.update(self.envvars)
+
+        wrapper_config_files = find_wrapper_config_files(self.path)
+        wrapper_config = parse_wrapper_configs(wrapper_config_files)
+        command_env.update(resolve_envvars(wrapper_config.envvars))
 
         if debug:
             command_env["TF_LOG"] = "DEBUG"

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.6.15"
+__version__ = "0.6.16"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
This fixes a bug where we try to read SSM params for directories that we don't plan to execute because they are outside the root directory that's being applied