### PR TITLE
Delete Terraform Lock Files

### DIFF
--- a/bin/tf
+++ b/bin/tf
@@ -89,6 +89,9 @@ def exec_tf_command(
 
     if command == "init":
         shutil.rmtree(os.path.join(path, ".terraform"), ignore_errors=True)
+        lock_file_path = os.path.join(path, ".terraform.lock.hcl")
+        if os.path.exists(lock_file_path):
+            os.remove(lock_file_path)
 
     if command == "import":
         response = input(

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
We already delete the .terraform directory on init, so we should also
delete the lock file. We can make both behaviors configurable later on.