### PR TITLE
Update PyYAML version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2021-02-23
+
+### Changed
+
+-   Update `PyYAML` package to version >=5.3.1,<6
+
 ## [0.8.2] - 2021-02-19
 
 ### Changed

--- a/requirements.pip
+++ b/requirements.pip
@@ -4,7 +4,7 @@ amplify-aws-utils>=0.1.2
 docopt==0.6.2
 filelock>=3.0.12,<4
 gitpython>=2.1.10
-pyyaml>=3.13,<4
+PyYAML>=5.3.1,<6
 ssm-cache>=2.7,<3
 jsons>=1.0.0,<1.2.0
 python-hcl2>=2,<3

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
I have created PR in [terraform-config](https://github.com/amplify-education/terraform-config/pull/6186/files)
In which trying to update the python dependencies. And this update shows [conflicts](https://mhcskylightjenkins-build.aws.wgen.net/jenkins/view/Sandbox/job/sandbox-terraform-create/1296/console)

![Screen Shot 2021-02-23 at 1 21 41 PM](https://user-images.githubusercontent.com/4427554/108836881-17f22e80-75da-11eb-899b-df4aa30ee4d0.png)

So set the same PyYAML version as in [astrotools](https://github.com/amplify-education/astrotools_tools/blob/master/requirements.pip#L8)