### PR TITLE
BugFix: Fix parsing of the wrap file config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.8.8] - 2021-04-20
+
+### Changed
+
+-   Fix parsing of the wrap file config
+
+## [0.8.7] - 2021-03-31
+
+### Changed
+
+-   Add parallel jobs option to the `plan_check`
+
 ## [0.8.6] - 2021-03-29
 
 ### Changed

--- a/terrawrap/utils/config.py
+++ b/terrawrap/utils/config.py
@@ -114,7 +114,8 @@ def create_wrapper_config_obj(config_dir, wrapper_file=None):
             if file.endswith(TF_WRAP_FILE):
                 wrapper_file = os.path.join(config_dir, file)
 
-    wrapper_config_obj: WrapperConfig = parse_wrapper_configs([wrapper_file])
+    wrapper_files = [wrapper_file] if wrapper_file else []
+    wrapper_config_obj: WrapperConfig = parse_wrapper_configs(wrapper_files)
     if wrapper_config_obj.depends_on:
         depends_on = []
         for dependency in wrapper_config_obj.depends_on:

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.8.7"
+__version__ = "0.8.8"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
Small fix for handling such error
```
Traceback (most recent call last):

  File "/root/.pyenv/versions/3.7.10/bin/graph_apply", line 123, in <module>

    main()

  File "/root/.pyenv/versions/3.7.10/bin/graph_apply", line 68, in main

    graph, post_graph = walk_and_graph_directory(config_dir, wrapper_config_dict)

  File "/root/.pyenv/versions/3.7.10/lib/python3.7/site-packages/terrawrap/utils/config.py", line 156, in walk_and_graph_directory

    graph_wrapper_dependencies(root, config_dict, single_config_dependency_graph, visited)

  File "/root/.pyenv/versions/3.7.10/lib/python3.7/site-packages/terrawrap/utils/config.py", line 255, in graph_wrapper_dependencies

    graph_wrapper_dependencies(predecessor, config_dict, graph, visited)

  File "/root/.pyenv/versions/3.7.10/lib/python3.7/site-packages/terrawrap/utils/config.py", line 208, in graph_wrapper_dependencies

    wrapper_config_obj = create_wrapper_config_obj(config_dir)

  File "/root/.pyenv/versions/3.7.10/lib/python3.7/site-packages/terrawrap/utils/config.py", line 117, in create_wrapper_config_obj

    wrapper_config_obj: WrapperConfig = parse_wrapper_configs([wrapper_file])

  File "/root/.pyenv/versions/3.7.10/lib/python3.7/site-packages/terrawrap/utils/config.py", line 82, in parse_wrapper_configs

    with open(wrapper_config_path) as wrapper_config_file:

TypeError: expected str, bytes or os.PathLike object, not NoneType
```