### PR TITLE
AT-4667 Fix Plan Check for Terraform 0.15

### DIFF
--- a/bin/plan_check
+++ b/bin/plan_check
@@ -95,7 +95,7 @@ def init_and_plan_directory(
     :return: One of the WrapperExitCode enums
     """
 
-    arguments = ['-lock=false', '-input=false']
+    arguments = ['-input=false']
 
     if not with_colors:
         arguments.append('-no-color')
@@ -126,7 +126,7 @@ def init_and_plan_directory(
     # the constructor. We are then passing in those environment variables explicitly in the
     # execute_command call below.
     plan_exit_code, plan_stdout = execute_command(
-        [wrapper_py, "--no-resolve-envvars", directory, 'plan', '-detailed-exitcode'] + arguments,
+        [wrapper_py, "--no-resolve-envvars", directory, 'plan', '-detailed-exitcode', '-lock=false'] + arguments,
         print_output=False,
         env=command_env
     )

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.8.8"
+__version__ = "0.8.9"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
Apparently, Terraform 0.15 no longer allows -lock=false for the init
command, so we cannot pass it as an argument in plan_check anymore. So
instead only pass it when we are running the actual plan command.

-lock=false apparently never did anything for init in the first place,
so it should be safe to remove this entirely without trying to do some
kind of version check.