### PR TITLE
Fix: Graph Apply Retries

### DIFF
--- a/bin/graph_apply
+++ b/bin/graph_apply
@@ -32,7 +32,7 @@ from terrawrap.utils.version import version_check
 from terrawrap.version import __version__
 
 from terrawrap.utils.config import walk_and_graph_directory, walk_without_graph_directory
-from terrawrap.utils.graph import find_source_nodes, generate_dependencies, visualize, has_cycle, connect_symlinks
+from terrawrap.utils.graph import find_source_nodes, generate_dependencies, visualize, connect_symlinks
 from terrawrap.models.graph import ApplyGraph
 from terrawrap.utils.path import get_symlinks
 

--- a/requirements.pip
+++ b/requirements.pip
@@ -10,5 +10,5 @@ jsons>=1.0.0,<2.0.0
 python-hcl2>=2,<3
 # Packaging does not obey semver
 packaging==19.1
-diskcache>=4.0.0,<5
+diskcache>=5.0.0,<6
 networkx>=2.4

--- a/requirements.pip
+++ b/requirements.pip
@@ -6,7 +6,7 @@ filelock>=3.0.12,<4
 gitpython>=2.1.10
 PyYAML>=5.3.1,<6
 ssm-cache>=2.7,<3
-jsons>=1.0.0,<1.2.0
+jsons>=1.0.0,<2.0.0
 python-hcl2>=2,<3
 # Packaging does not obey semver
 packaging==19.1

--- a/terrawrap/models/graph.py
+++ b/terrawrap/models/graph.py
@@ -52,7 +52,7 @@ class ApplyGraph:
                 if stdout and print_only_changes and not changes_detected:
                     stdout = ["No changes detected.\n"]
 
-                print("Output:\n\n%s\n" % "".join(stdout).strip())
+                print("Output for %s:\n\n%s\n" % (path, "".join(stdout).strip()))
 
                 if exit_code != 0:
                     self.failures.append(path)
@@ -104,7 +104,7 @@ class ApplyGraph:
             if stdout and print_only_changes and not changes_detected:
                 stdout = ["No changes detected.\n"]
 
-            print("Output:\n\n%s\n" % "".join(stdout).strip())
+            print("Output for %s:\n\n%s\n" % (path, "".join(stdout).strip()))
             if exit_code != 0:
                 self.failures.append(path)
 
@@ -144,7 +144,7 @@ class ApplyGraph:
                     if print_only_changes and not changes_detected:
                         stdout = ["No changes detected.\n"]
 
-                    print("Output:\n\n%s\n" % "".join(stdout).strip())
+                    print("Output for %s:\n\n%s\n" % (path, "".join(stdout).strip()))
 
                     if exit_code != 0:
                         self.failures.append(path)

--- a/terrawrap/models/graph_entry.py
+++ b/terrawrap/models/graph_entry.py
@@ -87,11 +87,11 @@ class GraphEntry(Entry):
 
         shell = False
         if operation in ["apply", "destroy"]:
-            operation_args = " ".join(["yes", "yes", "|"] + operation_args)
+            operation_args = ["yes", "yes", "|"] + operation_args
             shell = True
 
         operation_exit_code, operation_stdout = execute_command(
-            operation_args,
+            " ".join(operation_args) if shell else operation_args,
             print_output=False,
             capture_stderr=True,
             env=command_env,

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -67,7 +67,7 @@ def execute_command(
         try_count += 1
 
         network_errors = _get_retriable_errors(stdout)
-        if network_errors and retry:
+        if exit_code != 0 and network_errors and retry:
             logger.warning('Found network errors while running %s command: %s', args, network_errors)
         else:
             # The command either succeeded or failed with a non network error. don't retry

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -55,8 +55,14 @@ def execute_command(
     exit_code = 0
     stdout: List[str] = []
     while try_count < max_tries:
-        exit_code, stdout = _execute_command(args, print_output, capture_stderr, print_command,
-                                             *pargs, **kwargs)
+        exit_code, stdout = _execute_command(
+            args,
+            print_output,
+            capture_stderr,
+            print_command,
+            *pargs,
+            **kwargs,
+        )
 
         try_count += 1
 

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import logging
 import subprocess
 import tempfile
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 from amplify_aws_utils.resource_helper import Jitter
 
@@ -26,7 +26,7 @@ RETRIABLE_ERRORS = [
 
 
 def execute_command(
-        args: List[str],
+        args: Union[List[str], str],
         *pargs,
         print_output: bool = True,
         capture_stderr: bool = True,
@@ -37,7 +37,7 @@ def execute_command(
 ) -> Tuple[int, List[str]]:
     """
     Convenience function for executing a given command and optionally printing the output.
-    :param args: List of arguments to execute.
+    :param args: List of arguments to execute, or a single string.
     :param pargs: Any additional positional arguments to Popen.
     :param print_output: True if the output of the command should be printed immediately. Defaults to True.
     :param capture_stderr: True if stderr should be captured. Defaults to True.
@@ -82,7 +82,7 @@ def execute_command(
 
 
 def _execute_command(
-        args: List[str],
+        args: Union[List[str], str],
         print_output: bool,
         capture_stderr: bool,
         print_command: bool,
@@ -91,7 +91,7 @@ def _execute_command(
 ) -> Tuple[int, List[str]]:
     """
     Private function for executing a given command and optionally printing the output.
-    :param args: List of arguments to execute.
+    :param args: List of arguments to execute, or a single string.
     :param print_output: True if the output of the command should be printed immediately. Defaults to True.
     :param capture_stderr: True if stderr should be captured. Defaults to True.
     :param print_command: True if the command should be printed before executing. Defaults to False.

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.8.9"
+__version__ = "0.8.10"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -33,7 +33,7 @@ class TestCli(TestCase):
     @patch('io.open')
     def test_execute_command_retry(self, mock_open, mock_network_error):
         """Test retrying execution because of network errors"""
-        self.mock_process.poll.return_value = 0
+        self.mock_process.poll.side_effect = [1, 1, 1, 0]
         mock_network_error.side_effect = [["Throttling"], []]
         mock_stdout_read = mock_open.return_value
         mock_stdout_read.readline.return_value = b''

--- a/test/unit/test_graph_entry.py
+++ b/test/unit/test_graph_entry.py
@@ -12,14 +12,17 @@ class TestGraphEntry(TestCase):
     @patch('terrawrap.models.graph_entry.execute_command')
     def test_execute(self, exec_command):
         """Test executing a command successfully"""
-        exec_command.side_effect = [(0, ['Success'])]
+        exec_command.side_effect = [
+            (0, ['Success']),
+            (0, ['Success']),
+        ]
 
         entry = GraphEntry('/var', [])
         exit_code, stdout, changes_detected = entry.execute('plan')
 
         self.assertEqual(exit_code, 0)
-        self.assertEqual(stdout, ['Success', '\n'])
-        self.assertEqual(changes_detected, False)
+        self.assertEqual(stdout, ['Success', '\n', 'Success'])
+        self.assertEqual(changes_detected, True)
 
     @patch('terrawrap.models.graph_entry.execute_command')
     def test_execute_fail(self, exec_command):
@@ -38,7 +41,6 @@ class TestGraphEntry(TestCase):
         """Test executing apply with changes"""
         exec_command.side_effect = [
             (0, ['Success']),
-            (2, ['Something changed']),
             (0, ['Success']),
         ]
 
@@ -46,7 +48,7 @@ class TestGraphEntry(TestCase):
         exit_code, stdout, changes_detected = entry.execute('apply')
 
         self.assertEqual(exit_code, 0)
-        self.assertEqual(stdout, ['Success', '\n', 'Something changed', '\n', 'Success'])
+        self.assertEqual(stdout, ['Success', '\n', 'Success'])
         self.assertEqual(changes_detected, True)
 
     @patch('terrawrap.models.graph_entry.execute_command')
@@ -54,12 +56,12 @@ class TestGraphEntry(TestCase):
         """Test executing apply with no changes"""
         exec_command.side_effect = [
             (0, ['Success']),
-            (0, ['Nothing changed']),
+            (0, ['Resources: 0 added, 0 changed, 0 destroyed']),
         ]
 
         entry = GraphEntry('/var', [])
         exit_code, stdout, changes_detected = entry.execute('apply')
 
         self.assertEqual(exit_code, 0)
-        self.assertEqual(stdout, ['Success', '\n', 'Nothing changed'])
+        self.assertEqual(stdout, ['Success', '\n', 'Resources: 0 added, 0 changed, 0 destroyed'])
         self.assertEqual(changes_detected, False)


### PR DESCRIPTION
Removed the plan and apply logic from graph_apply. Instead, we will always run apply and use the yes command to auto accept the prompt so that we still get a proper plan output from the command. This will fix the issue where the graph_apply would occasionally run into a transient error when applying, but then would fail again because the plan it was trying to apply was out of date.

Also tried to improve the output from graph_apply by making sure that the directory that finished running was printed along without the output, as this was sometimes unclear...

Also some minor formatting and lint fixes.