### PR TITLE
Fix: Ignore State Warnings

### DIFF
--- a/bin/plan_check
+++ b/bin/plan_check
@@ -40,6 +40,7 @@ from terrawrap.utils.tf_variables import get_auto_var_usage_graph
 
 from networkx import compose_all, descendants
 
+TERRAFORM_PERFORM_ACTIONS = "Terraform will perform the following actions"
 IAM_POLICY_RE = re.compile('[-~+] .*(aws_iam_|aws_s3_bucket_policy).*')
 SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
 CURRENT_DIRECTORY = os.getcwd()
@@ -160,13 +161,20 @@ def check_for_iam_changes(stdout: List[str], directory: str) -> WrapperExitCode:
     :param directory: A directory with the config to be printed along with the notification about IAM changes
     :return: One of the WrapperExitCode enums
     """
-
     iam_resources = []
+    reached_actual_changes = False
 
     for line in stdout:
-        match = re.search(IAM_POLICY_RE, line)
-        if match:
-            iam_resources.append(match.group(0))
+        # TODO: Refactor this to use JSON at some point
+        # https://www.terraform.io/docs/internals/json-format.html
+        if not reached_actual_changes and TERRAFORM_PERFORM_ACTIONS in line:
+            reached_actual_changes = True
+
+        if reached_actual_changes:
+            match = re.search(IAM_POLICY_RE, line)
+            if match:
+                iam_resources.append(match.group(0))
+
     if iam_resources:
         print("Detected IAM resources modified in {0}:\n{1}\n".format(directory, "\n".join(iam_resources)))
         return WrapperExitCode.IAM_CHANGES

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.8.12"
+__version__ = "0.8.13"
 __git_hash__ = "GIT_HASH"

--- a/test-requirements.pip
+++ b/test-requirements.pip
@@ -2,6 +2,12 @@
 pycodestyle
 pylint>=2.3.1,<3
 mypy
+# mypy types
+types-PyYAML>=5.4.3,<6
+types-filelock>=0.1.4,<1
+types-mock>=0.1.3,<1
+types-requests>=2.25.0,<3
+types-six>=0.1.7,<1
 # Testing tools
 nose>=1.1,<2
 nose-cov>=1.5,<2


### PR DESCRIPTION
The latest version of Terraform will evaluate data sources as print out any diffs that it finds separately, with a note that the Terraform plan might affect those resources.

This change will ignore the output of the plan command in the plan_check until we get to the actual changes that Terraform intends to make, which might include those IAM resources that it warned about above. If the resources are actually included there, then they will be changed and it would be appropriate to flag the plan. If they aren't actually included there, the Terraform engine has decided that the config is sufficiently close that no changes are necessary and we shouldn't flag the plan.