### PR TITLE
Fix: Backend Check Under Python 3.9

### DIFF
--- a/bin/backend_check
+++ b/bin/backend_check
@@ -36,7 +36,7 @@ def main():
         for path in arguments["PATHS"]
     }
 
-    with concurrent.futures.ProcessPoolExecutor() as executor:
+    with concurrent.futures.ThreadPoolExecutor() as executor:
         futures_to_dirs = {
             executor.submit(
                 check_directory_for_backend,

--- a/terrawrap/models/wrapper_config.py
+++ b/terrawrap/models/wrapper_config.py
@@ -45,7 +45,7 @@ class S3BackendConfig:
 
 
 class GCSBackendConfig:
-    def __init__(self, bucket: str):
+    def __init__(self, bucket: str = None):
         self.bucket = bucket
 
 

--- a/terrawrap/utils/config.py
+++ b/terrawrap/utils/config.py
@@ -7,6 +7,7 @@ import networkx
 import hcl2
 import jsons
 import yaml
+from jsons import DeserializationError
 from ssm_cache import SSMParameterGroup
 
 from terrawrap.exceptions import NotTerraformConfigDirectory, NoDependency
@@ -84,8 +85,12 @@ def parse_wrapper_configs(wrapper_config_files: List[str]) -> WrapperConfig:
             if wrapper_config and isinstance(wrapper_config, dict):
                 generated_wrapper_config = update(generated_wrapper_config, wrapper_config)
 
-    wrapper_config_obj: WrapperConfig = jsons.load(generated_wrapper_config, WrapperConfig, strict=True)
-    return wrapper_config_obj
+    try:
+        wrapper_config_obj: WrapperConfig = jsons.load(generated_wrapper_config, WrapperConfig, strict=True)
+        return wrapper_config_obj
+    except DeserializationError as exception:
+        print(f"Cannot parse wrapper config from files: {wrapper_config_files}")
+        raise exception
 
 
 def is_config_directory(directory: str) -> bool:

--- a/terrawrap/utils/plugin_download.py
+++ b/terrawrap/utils/plugin_download.py
@@ -39,6 +39,9 @@ class PluginDownload:
             path_with_platform = f'{path}/{system}/{machine}'
 
             lock_path = f'{file_path}.{"lock"}'
+            # It seems that this is the name of the abstract class, but also an alias for the proper class, so
+            # this warning is not relevant for us.
+            # pylint: disable=abstract-class-instantiated
             lock = FileLock(lock_path, timeout=600)
             # use a lock to prevent conflicts writing the file if running this command in parallel
             with lock:

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.8.22"
+__version__ = "0.8.23"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
The root seems to be that we were using ProcessPool and not ThreadPool. There doesn't seem to be a particularly good reason why we were doing that, so just switching to ThreadPool resolved that.

Also a few other little fixes sprinkled in as I was testing this against terraform-config...