### PR TITLE
Fix: Convert Envvars to String

### DIFF
--- a/terrawrap/utils/config.py
+++ b/terrawrap/utils/config.py
@@ -274,7 +274,7 @@ def resolve_envvars(envvar_configs: Dict[str, AbstractEnvVarConfig]) -> Dict[str
         if isinstance(envvar_config, SSMEnvVarConfig):
             resolved_envvars[envvar_name] = SSM_ENVVAR_CACHE.parameter(envvar_config.path).value
         if isinstance(envvar_config, TextEnvVarConfig):
-            resolved_envvars[envvar_name] = envvar_config.value
+            resolved_envvars[envvar_name] = str(envvar_config.value)
     return resolved_envvars
 
 

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.8.23"
+__version__ = "0.8.24"
 __git_hash__ = "GIT_HASH"

--- a/test/helpers/mock_directory/config/.tf_wrapper
+++ b/test/helpers/mock_directory/config/.tf_wrapper
@@ -8,3 +8,6 @@ envvars:
   SSM_KEY:
     source: ssm
     path: FAKE_SSM_PATH
+  NOT_A_STRING:
+    source: text
+    value: 10

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -272,4 +272,5 @@ class TestConfig(TestCase):
         self.assertEqual("OVERWRITTEN_VALUE", actual_envvars["OVERWRITTEN_KEY"])
         self.assertEqual("HARDCODED_VALUE", actual_envvars["HARDCODED_KEY"])
         self.assertEqual("SSM_VALUE", actual_envvars["SSM_KEY"])
+        self.assertEqual("10", actual_envvars["NOT_A_STRING"])
         mock_ssm_cache.parameter.assert_called_once_with("FAKE_SSM_PATH")


### PR DESCRIPTION
Python's Popen doesn't tolerate integers, booleans, etc as envvars. Instead they must be strings or file objects. So just convert the text-based envvars to always be strings.