### PR TITLE
Fixing terraform-audit-api directory path

### DIFF
--- a/bin/tf
+++ b/bin/tf
@@ -113,8 +113,7 @@ def exec_tf_command(
             print_command=True,
             retry=True,
             env=command_env,
-            audit_api_url=audit_api_url,
-            path=path
+            audit_api_url=audit_api_url
         )
 
         try_count += 1

--- a/bin/tf
+++ b/bin/tf
@@ -113,7 +113,8 @@ def exec_tf_command(
             print_command=True,
             retry=True,
             env=command_env,
-            audit_api_url=audit_api_url
+            audit_api_url=audit_api_url,
+            path=path
         )
 
         try_count += 1

--- a/terrawrap/models/graph_entry.py
+++ b/terrawrap/models/graph_entry.py
@@ -96,7 +96,8 @@ class GraphEntry(Entry):
             capture_stderr=True,
             env=command_env,
             shell=shell,
-            audit_api_url=self.wrapper_config.audit_api_url
+            audit_api_url=self.wrapper_config.audit_api_url,
+            path=self.path
         )
 
         if operation_exit_code == 0:

--- a/terrawrap/models/graph_entry.py
+++ b/terrawrap/models/graph_entry.py
@@ -97,7 +97,7 @@ class GraphEntry(Entry):
             env=command_env,
             shell=shell,
             audit_api_url=self.wrapper_config.audit_api_url,
-            path=self.path
+            cwd=self.path
         )
 
         if operation_exit_code == 0:

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -42,6 +42,7 @@ def execute_command(
         retry: bool = False,
         timeout: int = 15 * 60,
         audit_api_url: str = None,
+        path: str = None,
         **kwargs,
 ) -> Tuple[int, List[str]]:
     """
@@ -96,7 +97,7 @@ def execute_command(
         time_passed = jitter.backoff()
 
     if audit_api_url:
-        _post_to_audit_api_url(audit_api_url, args[0], exit_code, stdout)
+        _post_to_audit_api_url(audit_api_url, path, exit_code, stdout)
 
     return exit_code, stdout
 
@@ -163,11 +164,11 @@ def _get_retriable_errors(out: List[str]) -> List[str]:
     ]
 
 
-def _post_to_audit_api_url(audit_api_url: str, directory: str, exit_code: int, stdout: List[str]):
+def _post_to_audit_api_url(audit_api_url: str, path: str, exit_code: int, stdout: List[str]):
     try:
         requests.post(
             audit_api_url, json={
-                'directory': directory,
+                'directory': path,
                 'status': 'SUCCESS' if exit_code == 0 else 'FAILED',
                 'run_by': getpass.getuser(),
                 'output': stdout

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -42,8 +42,7 @@ def execute_command(
         retry: bool = False,
         timeout: int = 15 * 60,
         audit_api_url: str = None,
-        path: str = None,
-        **kwargs,
+        **kwargs
 ) -> Tuple[int, List[str]]:
     """
     Convenience function for executing a given command and optionally printing the output.
@@ -96,8 +95,8 @@ def execute_command(
 
         time_passed = jitter.backoff()
 
-    if audit_api_url:
-        _post_to_audit_api_url(audit_api_url, path, exit_code, stdout)
+    if audit_api_url and kwargs['cwd']:
+        _post_to_audit_api_url(audit_api_url, kwargs['cwd'], exit_code, stdout)
 
     return exit_code, stdout
 

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.8.26"
+__version__ = "0.8.27"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -77,7 +77,7 @@ class TestCli(TestCase):
 
         with requests_mock.Mocker() as mocker:
             mocker.register_uri(requests_mock.ANY, requests_mock.ANY, text='test message')
-            execute_command(['test', '0'], audit_api_url='http://test.com', path='test/path')
+            execute_command(['test', '0'], audit_api_url='http://test.com', cwd='test/path')
 
             assert mocker.called_once
             assert mocker.last_request.body.decode('utf-8') == expected_body

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -73,11 +73,11 @@ class TestCli(TestCase):
     def test_set_audit_api_url(self, mock_getuser_func):
         """Test sending data to given url"""
         mock_getuser_func.return_value = 'mockuser'
-        expected_body = '{"directory": "test", "status": "FAILED", "run_by": "mockuser", "output": []}'
+        expected_body = '{"directory": "test/path", "status": "FAILED", "run_by": "mockuser", "output": []}'
 
         with requests_mock.Mocker() as mocker:
             mocker.register_uri(requests_mock.ANY, requests_mock.ANY, text='test message')
-            execute_command(['test', '0'], audit_api_url='http://test.com')
+            execute_command(['test', '0'], audit_api_url='http://test.com', path='test/path')
 
             assert mocker.called_once
             assert mocker.last_request.body.decode('utf-8') == expected_body


### PR DESCRIPTION
Adding path option to execute_command to pass directory path to terraform-audit-api. Previously was sending first argument in command (usually just `terraform`, changed to actual path).

Ex. `config/aws/amplify-devops/devops/astrotools/terraform_audit_api`