### PR TITLE
Fix `terraform-audit-api` Directory Bug

### DIFF
--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -170,14 +170,15 @@ def _get_retriable_errors(out: List[str]) -> List[str]:
 
 def _post_to_audit_api_url(audit_api_url: str, path: str, exit_code: int, stdout: List[str]):
     root = get_git_root(path)
+    path = path.replace(root, '')
 
     try:
         requests.post(
             audit_api_url, json={
-                'directory': root,
+                'directory': path,
                 'status': 'SUCCESS' if exit_code == 0 else 'FAILED',
                 'run_by': getpass.getuser(),
                 'output': stdout
             })
     except requests.exceptions.RequestException:
-        logger.error(f"Unable to post data to provided url: {audit_api_url}")
+        logger.error("Unable to post data to provided url: %s", audit_api_url)

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -8,11 +8,11 @@ import tempfile
 
 from typing import List, Tuple, Union
 
-from terrawrap.utils.git_utils import get_git_root
-
 import requests
 
 from amplify_aws_utils.resource_helper import Jitter
+
+from terrawrap.utils.git_utils import get_git_root
 
 logger = logging.getLogger(__name__)
 

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -8,6 +8,8 @@ import tempfile
 
 from typing import List, Tuple, Union
 
+from terrawrap.utils.git_utils import get_git_root
+
 import requests
 
 from amplify_aws_utils.resource_helper import Jitter
@@ -167,15 +169,15 @@ def _get_retriable_errors(out: List[str]) -> List[str]:
 
 
 def _post_to_audit_api_url(audit_api_url: str, path: str, exit_code: int, stdout: List[str]):
+    root = get_git_root(path)
+
     try:
         requests.post(
             audit_api_url, json={
-                'directory': path,
+                'directory': root,
                 'status': 'SUCCESS' if exit_code == 0 else 'FAILED',
                 'run_by': getpass.getuser(),
                 'output': stdout
             })
-    except requests.exceptions.RequestException as req_exception:
-        raise RuntimeError(
-            f"Unable to post data to provided url: {audit_api_url}"
-        ) from req_exception
+    except requests.exceptions.RequestException:
+        logger.error(f"Unable to post data to provided url: {audit_api_url}")

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.8.34"
+__version__ = "0.8.35"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -93,5 +93,8 @@ class TestCli(TestCase):
                 cwd=os.path.join(os.getcwd(), 'mock_directory/config/.tf_wrapper')
             )
 
+            response = mocker.last_request.body.decode('utf-8')
+            actual_body = json.loads(response)
+
             assert mocker.called_once
-            assert json.loads(mocker.last_request.body.decode('utf-8')) == expected_body
+            assert expected_body == actual_body

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -96,5 +96,5 @@ class TestCli(TestCase):
             response = mocker.last_request.body.decode('utf-8')
             actual_body = json.loads(response)
 
-            assert mocker.called_once
-            assert expected_body == actual_body
+            self.assertEqual(mocker.call_count, 1)
+            self.assertEqual(expected_body, actual_body)

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -81,7 +81,7 @@ class TestCli(TestCase):
             mocker.register_uri(requests_mock.ANY, requests_mock.ANY, text='test message')
             execute_command(
                 ['test', '0'],
-                audit_api_url='http://test.com',
+                audit_api_url='https://test.com',
                 cwd='/Users/bmontijo/Documents/GitHub/terrawrap/test/helpers/mock_directory/config/.tf_wrapper'
             )
 

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -73,11 +73,17 @@ class TestCli(TestCase):
     def test_set_audit_api_url(self, mock_getuser_func):
         """Test sending data to given url"""
         mock_getuser_func.return_value = 'mockuser'
-        expected_body = '{"directory": "test/path", "status": "FAILED", "run_by": "mockuser", "output": []}'
+
+        expected_body = '{"directory": "/test/helpers/mock_directory/config/.tf_wrapper", ' \
+                        '"status": "FAILED", "run_by": "mockuser", "output": []}'
 
         with requests_mock.Mocker() as mocker:
             mocker.register_uri(requests_mock.ANY, requests_mock.ANY, text='test message')
-            execute_command(['test', '0'], audit_api_url='http://test.com', cwd='test/path')
+            execute_command(
+                ['test', '0'],
+                audit_api_url='http://test.com',
+                cwd='/Users/bmontijo/Documents/GitHub/terrawrap/test/helpers/mock_directory/config/.tf_wrapper'
+            )
 
             assert mocker.called_once
             assert mocker.last_request.body.decode('utf-8') == expected_body

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -1,4 +1,5 @@
 """Test git utilities"""
+import os
 from unittest import TestCase
 from mock import patch
 
@@ -77,12 +78,14 @@ class TestCli(TestCase):
         expected_body = '{"directory": "/test/helpers/mock_directory/config/.tf_wrapper", ' \
                         '"status": "FAILED", "run_by": "mockuser", "output": []}'
 
+        os.chdir(os.path.normpath(os.path.dirname(__file__) + '/../helpers'))
+
         with requests_mock.Mocker() as mocker:
             mocker.register_uri(requests_mock.ANY, requests_mock.ANY, text='test message')
             execute_command(
                 ['test', '0'],
                 audit_api_url='https://test.com',
-                cwd='/Users/bmontijo/Documents/GitHub/terrawrap/test/helpers/mock_directory/config/.tf_wrapper'
+                cwd=os.path.join(os.getcwd(), 'mock_directory/config/.tf_wrapper')
             )
 
             assert mocker.called_once

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -1,4 +1,5 @@
 """Test git utilities"""
+import json
 import os
 from unittest import TestCase
 from mock import patch
@@ -75,8 +76,14 @@ class TestCli(TestCase):
         """Test sending data to given url"""
         mock_getuser_func.return_value = 'mockuser'
 
-        expected_body = '{"directory": "/test/helpers/mock_directory/config/.tf_wrapper", ' \
-                        '"status": "FAILED", "run_by": "mockuser", "output": []}'
+        expected_body = json.dumps(
+            {
+                'directory': '/test/helpers/mock_directory/config/.tf_wrapper',
+                'status': 'FAILED',
+                'run_by': 'mockuser',
+                'output': []
+            }
+        )
 
         os.chdir(os.path.normpath(os.path.dirname(__file__) + '/../helpers'))
 

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -76,14 +76,12 @@ class TestCli(TestCase):
         """Test sending data to given url"""
         mock_getuser_func.return_value = 'mockuser'
 
-        expected_body = json.dumps(
-            {
-                'directory': '/test/helpers/mock_directory/config/.tf_wrapper',
-                'status': 'FAILED',
-                'run_by': 'mockuser',
-                'output': []
-            }
-        )
+        expected_body = {
+            'directory': '/test/helpers/mock_directory/config/.tf_wrapper',
+            'status': 'FAILED',
+            'run_by': 'mockuser',
+            'output': []
+        }
 
         os.chdir(os.path.normpath(os.path.dirname(__file__) + '/../helpers'))
 
@@ -96,4 +94,4 @@ class TestCli(TestCase):
             )
 
             assert mocker.called_once
-            assert mocker.last_request.body.decode('utf-8') == expected_body
+            assert json.loads(mocker.last_request.body.decode('utf-8')) == expected_body


### PR DESCRIPTION
Updating `_post_to_audit_api_url` to use `get_git_root` to trim root off of posted directory. Also removed exception throwing when terrawrap fails to post to audit API