### PR TITLE
AT-6413 | Add `audit_api_url` and `cwd` parameters to graph_entry

### DIFF
--- a/terrawrap/models/graph_entry.py
+++ b/terrawrap/models/graph_entry.py
@@ -80,6 +80,8 @@ class GraphEntry(Entry):
             print_output=False,
             capture_stderr=True,
             env=command_env,
+            audit_api_url=self.wrapper_config.audit_api_url,
+            cwd=self.abs_path
         )
         if init_exit_code != 0:
             self.state = "Failed"

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.8.35"
+__version__ = "0.8.36"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
See JIRA for more information. 

Adding `audit_api_url` and `cwd`(path) to graph_entry.execute's `execute_command`. Prior to these changes, when running graph_apply, no data would be sent to terraform-audit-api since no url was provided.