### PR TITLE
AT 6519 | Add Support for `In Progress` Status

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -221,7 +221,7 @@ max-args=10
 ignored-argument-names=_.*
 
 # Maximum number of locals for function / method body
-max-locals=15
+max-locals=16
 
 # Maximum number of return / yield for function / method body
 max-returns=6

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -37,6 +37,8 @@ RETRIABLE_ERRORS = [
     'Api Rate Limit Exceeded',
     'TooManyUpdates',
 ]
+AUDIT_POST_PATH = '/audit_info'
+AUDIT_UPDATE_PATH = '/update_audit_info'
 
 
 def execute_command(
@@ -203,7 +205,7 @@ def _post_audit_info(
     user = getpass.getuser()
     logger.info('Attempting to send data to Audit API: %s run by %s(%s)', path, user, status)
 
-    url = (audit_api_url + '/update_audit_info') if update else (audit_api_url + '/audit_info')
+    url = (audit_api_url + AUDIT_UPDATE_PATH) if update else (audit_api_url + AUDIT_POST_PATH)
 
     try:
         requests.post(

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -83,14 +83,14 @@ def execute_command(
             if value is not None
         }
 
-    timestamp = time.time()
+    start_time = time.time()
 
     if audit_api_url and kwargs['cwd']:
         # Call _post_audit_info for working directory, setting status to 'in progress'
         _post_audit_info(
             audit_api_url=audit_api_url,
             path=kwargs['cwd'],
-            timestamp=timestamp,
+            start_time=start_time,
         )
 
     jitter = Jitter()
@@ -128,7 +128,7 @@ def execute_command(
             path=kwargs['cwd'],
             exit_code=exit_code,
             stdout=stdout,
-            timestamp=timestamp,
+            start_time=start_time,
             update=True
         )
 
@@ -202,7 +202,7 @@ def _post_audit_info(
         path: str = None,
         exit_code: int = None,
         stdout: List[str] = None,
-        timestamp: float = None,
+        start_time: float = None,
         update: bool = False
 ):
     root = get_git_root(path)
@@ -222,7 +222,7 @@ def _post_audit_info(
         requests.post(
             url, json={
                 'directory': path,
-                'timestamp': timestamp,
+                'start_time': start_time,
                 'status': status,
                 'run_by': user,
                 'output': stdout

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -203,7 +203,7 @@ def _post_audit_info(
     user = getpass.getuser()
     logger.info('Attempting to send data to Audit API: %s run by %s(%s)', path, user, status)
 
-    url = (audit_api_url + 'update_audit_info') if update else (audit_api_url + 'audit_info')
+    url = (audit_api_url + '/update_audit_info') if update else (audit_api_url + '/audit_info')
 
     try:
         requests.post(

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -5,6 +5,7 @@ import getpass
 import logging
 import subprocess
 import tempfile
+import time
 
 from typing import List, Tuple, Union
 
@@ -72,6 +73,12 @@ def execute_command(
             if value is not None
         }
 
+    timestamp = 1  # TODO - set this
+
+    if audit_api_url and kwargs['cwd']:
+        # Call _post_audit_info for working directory, setting status to 'in progress'
+        _post_audit_info(audit_api_url, kwargs['cwd'], '', timestamp)  # TODO - update params
+
     jitter = Jitter()
     time_passed = 0
     exit_code = 0
@@ -101,7 +108,8 @@ def execute_command(
         time_passed = jitter.backoff()
 
     if audit_api_url and kwargs['cwd']:
-        _post_to_audit_api_url(audit_api_url, kwargs['cwd'], exit_code, stdout)
+        # Call _post_audit_info again, this time to update the 'in progress' entry with new status and output
+        _post_audit_info(audit_api_url, kwargs['cwd'], exit_code, stdout, timestamp)  # TODO - update params
 
     return exit_code, stdout
 

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -213,7 +213,10 @@ def _post_audit_info(
     )
 
     logger.info('Getpass.getuser() will be used to grab the user running path: %s', path)
-    user = getpass.getuser()
+    try:
+        user = getpass.getuser()
+    except Exception:
+        user = 'System'
     logger.info('Attempting to send data to Audit API: %s run by %s(%s)', path, user, status)
 
     url = (audit_api_url + AUDIT_UPDATE_PATH) if update else (audit_api_url + AUDIT_POST_PATH)

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -73,7 +73,8 @@ def execute_command(
             if value is not None
         }
 
-    timestamp = 1  # TODO - set this
+    timestamp = int(time.time())
+    path = kwargs['cwd']
 
     if audit_api_url and kwargs['cwd']:
         # Call _post_audit_info for working directory, setting status to 'in progress'

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -43,6 +43,7 @@ AUDIT_UPDATE_PATH = '/update_audit_info'
 
 
 class Status(Enum):
+    """Enum for status of execute_command"""
     SUCCESS = 'SUCCESS'
     IN_PROGRESS = 'IN PROGRESS'
     FAILED = 'FAILED'

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -208,7 +208,7 @@ def _post_audit_info(
     root = get_git_root(path)
     path = path.replace(root, '')
 
-    status = Status.IN_PROGRESS if not exit_code else (
+    status = Status.IN_PROGRESS if exit_code is None else (
         Status.SUCCESS if exit_code == 0 else Status.FAILED
     )
 

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -42,7 +42,7 @@ AUDIT_POST_PATH = '/audit_info'
 AUDIT_UPDATE_PATH = '/update_audit_info'
 
 
-class Status(Enum):
+class Status(str, Enum):
     """Enum for status of execute_command"""
     SUCCESS = 'SUCCESS'
     IN_PROGRESS = 'IN PROGRESS'

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -198,11 +198,11 @@ def _get_retriable_errors(out: List[str]) -> List[str]:
 
 
 def _post_audit_info(
-        audit_api_url: str = '',
-        path: str = '',
+        audit_api_url: str,
+        path: str,
+        start_time: float,
         exit_code: int = None,
         stdout: List[str] = None,
-        start_time: float = None,
         update: bool = False
 ):
     root = get_git_root(path)

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -76,9 +76,13 @@ def execute_command(
     timestamp = int(time.time())
     path = kwargs['cwd']
 
-    if audit_api_url and kwargs['cwd']:
+    if audit_api_url and path:
         # Call _post_audit_info for working directory, setting status to 'in progress'
-        _post_audit_info(audit_api_url, kwargs['cwd'], '', timestamp)  # TODO - update params
+        _post_audit_info(
+            audit_api_url=audit_api_url,
+            path=path,
+            timestamp=timestamp,
+        )
 
     jitter = Jitter()
     time_passed = 0
@@ -108,9 +112,16 @@ def execute_command(
 
         time_passed = jitter.backoff()
 
-    if audit_api_url and kwargs['cwd']:
+    if audit_api_url and path:
         # Call _post_audit_info again, this time to update the 'in progress' entry with new status and output
-        _post_audit_info(audit_api_url, kwargs['cwd'], exit_code, stdout, timestamp)  # TODO - update params
+        _post_audit_info(
+            audit_api_url=audit_api_url,
+            path=path,
+            exit_code=exit_code,
+            stdout=stdout,
+            timestamp=timestamp,
+            update=True
+        )
 
     return exit_code, stdout
 

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -168,22 +168,29 @@ def _get_retriable_errors(out: List[str]) -> List[str]:
     ]
 
 
-def _post_to_audit_api_url(audit_api_url: str, path: str, exit_code: int, stdout: List[str]):
+def _post_audit_info(
+        audit_api_url: str = None,
+        path: str = None,
+        exit_code: int = None,
+        stdout: List[str] = None,
+        timestamp: int = None,
+        update: bool = False
+):
     root = get_git_root(path)
     path = path.replace(root, '')
 
-    status = 'SUCCESS' if exit_code == 0 else 'FAILED'
-
+    status = 'IN PROGRESS' if not exit_code else ('SUCCESS' if exit_code == 0 else 'FAILED')
     logger.info('Getpass.getuser() will be used to grab the user running path: %s', path)
-
     user = getpass.getuser()
-
     logger.info('Attempting to send data to Audit API: %s run by %s(%s)', path, user, status)
+
+    url = (audit_api_url + 'update_audit_info') if update else (audit_api_url + 'audit_info')
 
     try:
         requests.post(
-            audit_api_url, json={
+            url, json={
                 'directory': path,
+                'timestamp': timestamp,
                 'status': status,
                 'run_by': user,
                 'output': stdout

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -74,13 +74,12 @@ def execute_command(
         }
 
     timestamp = int(time.time())
-    path = kwargs['cwd']
 
-    if audit_api_url and path:
+    if audit_api_url and kwargs['cwd']:
         # Call _post_audit_info for working directory, setting status to 'in progress'
         _post_audit_info(
             audit_api_url=audit_api_url,
-            path=path,
+            path=kwargs['cwd'],
             timestamp=timestamp,
         )
 
@@ -112,11 +111,11 @@ def execute_command(
 
         time_passed = jitter.backoff()
 
-    if audit_api_url and path:
+    if audit_api_url and kwargs['cwd']:
         # Call _post_audit_info again, this time to update the 'in progress' entry with new status and output
         _post_audit_info(
             audit_api_url=audit_api_url,
-            path=path,
+            path=kwargs['cwd'],
             exit_code=exit_code,
             stdout=stdout,
             timestamp=timestamp,

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -198,8 +198,8 @@ def _get_retriable_errors(out: List[str]) -> List[str]:
 
 
 def _post_audit_info(
-        audit_api_url: str = None,
-        path: str = None,
+        audit_api_url: str = '',
+        path: str = '',
         exit_code: int = None,
         stdout: List[str] = None,
         start_time: float = None,

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.8.38"
+__version__ = "0.8.39"
 __git_hash__ = "GIT_HASH"

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.8.39"
+__version__ = "0.9.0"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -2,7 +2,7 @@
 import json
 import os
 from unittest import TestCase
-from mock import patch
+from mock import patch, MagicMock
 
 import requests_mock
 
@@ -72,16 +72,20 @@ class TestCli(TestCase):
         self.assertEqual(stdout, [])
 
     @patch('getpass.getuser')
-    def test_set_audit_api_url(self, mock_getuser_func):
+    @patch('time.time')
+    def test_set_audit_api_url(self, mock_time, mock_getuser_func):
         """Test sending data to given url"""
         mock_getuser_func.return_value = 'mockuser'
+        mock_time.return_value = 123
 
         expected_body = {
             'directory': '/test/helpers/mock_directory/config/.tf_wrapper',
+            'timestamp': 123,
             'status': 'FAILED',
             'run_by': 'mockuser',
             'output': []
         }
+
 
         os.chdir(os.path.normpath(os.path.dirname(__file__) + '/../helpers'))
 
@@ -96,5 +100,7 @@ class TestCli(TestCase):
             response = mocker.last_request.body.decode('utf-8')
             actual_body = json.loads(response)
 
-            self.assertEqual(mocker.call_count, 1)
+            self.assertEqual(mocker.call_count, 2)
+            print(expected_body)
+            print(actual_body)
             self.assertEqual(expected_body, actual_body)

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -6,7 +6,7 @@ from mock import patch
 
 import requests_mock
 
-from terrawrap.utils.cli import execute_command, MAX_RETRIES
+from terrawrap.utils.cli import execute_command, MAX_RETRIES, Status
 
 
 class TestCli(TestCase):
@@ -81,7 +81,7 @@ class TestCli(TestCase):
         expected_body = {
             'directory': '/test/helpers/mock_directory/config/.tf_wrapper',
             'start_time': 123,
-            'status': 'FAILED',
+            'status': Status.FAILED,
             'run_by': 'mockuser',
             'output': []
         }
@@ -100,6 +100,4 @@ class TestCli(TestCase):
             actual_body = json.loads(response)
 
             self.assertEqual(mocker.call_count, 2)
-            print(expected_body)
-            print(actual_body)
             self.assertEqual(expected_body, actual_body)

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -2,7 +2,7 @@
 import json
 import os
 from unittest import TestCase
-from mock import patch, MagicMock
+from mock import patch
 
 import requests_mock
 

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -2,7 +2,6 @@
 import json
 import os
 from unittest import TestCase
-from unittest.mock import MagicMock
 
 from mock import patch
 

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -86,7 +86,6 @@ class TestCli(TestCase):
             'output': []
         }
 
-
         os.chdir(os.path.normpath(os.path.dirname(__file__) + '/../helpers'))
 
         with requests_mock.Mocker() as mocker:

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -80,7 +80,7 @@ class TestCli(TestCase):
 
         expected_body = {
             'directory': '/test/helpers/mock_directory/config/.tf_wrapper',
-            'timestamp': 123,
+            'start_time': 123,
             'status': 'FAILED',
             'run_by': 'mockuser',
             'output': []


### PR DESCRIPTION
See [JIRA](https://amplify-education.atlassian.net/browse/AT-6519) for more info.

Updating `execute_command` to send data twice per run, once to create an entry in terraform-audit-api's DynamoDB table with status `In Progress`, and once more after the command is executed to update the status and output. 

These changes depend on the following PRs:

- [Rename `audit_api_url`](https://amplify-education.atlassian.net/browse/AT-6519)
- [Update Audit API](https://github.com/amplify-education/terraform-audit-api/pull/14)
- [Rename `timestamp`](https://github.com/amplify-education/terraform-config/pull/12102)

 All PRs should be merged around the same time to avoid any errors.