### PR TITLE
Fix: Temporarily remove Audit API calls from `execute_command`

### DIFF
--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -83,7 +83,7 @@ def execute_command(
             if value is not None
         }
 
-    start_time = time.time()
+    # start_time = time.time() TODO - UNCOMMENT BELOW ONCE API IS UPDATED
 
     if audit_api_url and kwargs['cwd']:
         # Call _post_audit_info for working directory, setting status to 'in progress'

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -87,11 +87,12 @@ def execute_command(
 
     if audit_api_url and kwargs['cwd']:
         # Call _post_audit_info for working directory, setting status to 'in progress'
-        _post_audit_info(
-            audit_api_url=audit_api_url,
-            path=kwargs['cwd'],
-            start_time=start_time,
-        )
+        pass  # TODO - REMOVE THIS AND UNCOMMENT BELOW ONCE API IS UPDATED
+        # _post_audit_info(
+        #     audit_api_url=audit_api_url,
+        #     path=kwargs['cwd'],
+        #     start_time=start_time,
+        # )
 
     jitter = Jitter()
     time_passed = 0
@@ -123,14 +124,15 @@ def execute_command(
 
     if audit_api_url and kwargs['cwd']:
         # Call _post_audit_info again, this time to update the 'in progress' entry with new status and output
-        _post_audit_info(
-            audit_api_url=audit_api_url,
-            path=kwargs['cwd'],
-            exit_code=exit_code,
-            stdout=stdout,
-            start_time=start_time,
-            update=True
-        )
+        pass  # TODO - REMOVE THIS AND UNCOMMENT BELOW ONCE API IS UPDATED
+        # _post_audit_info(
+        #     audit_api_url=audit_api_url,
+        #     path=kwargs['cwd'],
+        #     exit_code=exit_code,
+        #     stdout=stdout,
+        #     start_time=start_time,
+        #     update=True
+        # )
 
     return exit_code, stdout
 

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -5,7 +5,6 @@ import getpass
 import logging
 import subprocess
 import tempfile
-import time
 from enum import Enum
 
 from typing import List, Tuple, Union

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -72,34 +72,34 @@ class TestCli(TestCase):
         self.assertEqual(exit_code, 255)
         self.assertEqual(stdout, [])
 
-    @patch('getpass.getuser')
-    @patch('time.time')
-    def test_set_audit_api_url(self, mock_time, mock_getuser_func):
-        """Test sending data to given url"""
-        mock_getuser_func.return_value = 'mockuser'
-        mock_time.return_value = 123
-
-        expected_body = {
-            'directory': '/test/helpers/mock_directory/config/.tf_wrapper',
-            'start_time': 123,
-            'status': Status.FAILED,
-            'run_by': 'mockuser',
-            'output': []
-        }
-
-        with requests_mock.Mocker() as mocker:
-            mocker.register_uri(requests_mock.ANY, requests_mock.ANY, text='test message')
-            execute_command(
-                ['test', '0'],
-                audit_api_url='https://test.com',
-                cwd=os.path.join(os.getcwd(), 'mock_directory/config/.tf_wrapper')
-            )
-
-            response = mocker.last_request.body.decode('utf-8')
-            actual_body = json.loads(response)
-
-            self.assertEqual(mocker.call_count, 2)
-            self.assertEqual(expected_body, actual_body)
+    # @patch('getpass.getuser')
+    # @patch('time.time')
+    # def test_set_audit_api_url(self, mock_time, mock_getuser_func):
+    #     """Test sending data to given url"""
+    #     mock_getuser_func.return_value = 'mockuser'
+    #     mock_time.return_value = 123
+    #
+    #     expected_body = {
+    #         'directory': '/test/helpers/mock_directory/config/.tf_wrapper',
+    #         'start_time': 123,
+    #         'status': Status.FAILED,
+    #         'run_by': 'mockuser',
+    #         'output': []
+    #     }
+    #
+    #     with requests_mock.Mocker() as mocker:
+    #         mocker.register_uri(requests_mock.ANY, requests_mock.ANY, text='test message')
+    #         execute_command(
+    #             ['test', '0'],
+    #             audit_api_url='https://test.com',
+    #             cwd=os.path.join(os.getcwd(), 'mock_directory/config/.tf_wrapper')
+    #         )
+    #
+    #         response = mocker.last_request.body.decode('utf-8')
+    #         actual_body = json.loads(response)
+    #
+    #         self.assertEqual(mocker.call_count, 2)
+    #         self.assertEqual(expected_body, actual_body)
 
     @patch('getpass.getuser')
     @patch('requests.post')

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -1,11 +1,9 @@
 """Test git utilities"""
-import json
 import os
 from unittest import TestCase
 
 from mock import patch
 
-import requests_mock
 
 from terrawrap.utils.cli import execute_command, MAX_RETRIES, Status, _post_audit_info
 

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -72,7 +72,7 @@ class TestCli(TestCase):
         self.assertEqual(exit_code, 255)
         self.assertEqual(stdout, [])
 
-    # @patch('getpass.getuser')
+    # @patch('getpass.getuser')  TODO - UNCOMMENT BELOW ONCE API IS UPDATED
     # @patch('time.time')
     # def test_set_audit_api_url(self, mock_time, mock_getuser_func):
     #     """Test sending data to given url"""


### PR DESCRIPTION
Quick PR - Removing this so terrawrap won't unexpectedly error out while working on fixing API