### PR TITLE
Phase out `python3.6`

### DIFF
--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -15,7 +15,7 @@ jobs:
         runs-on: ubuntu-18.04
         strategy:
           matrix:
-            python-version: [3.6, 3.7, 3.8, 3.9]
+            python-version: [3.7, 3.8, 3.9]
         steps:
         - uses: actions/checkout@master
         - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Learn more at <https://www.amplify.com>
 
 ### Prerequisites
 
-Terrawrap requires Python 3.6.0 or higher to run.
+Terrawrap requires Python 3.7.0 or higher to run.
 
 ### Installing
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ def get_requirements():
 
 setup(
     name='terrawrap',
-    python_requires='>=3.6.0',
+    python_requires='>=3.7.0',
     version=get_version(),
     description="Set of Python-based CLI tools for working with Terraform configurations",
     long_description=get_long_description(),
@@ -54,7 +54,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 __git_hash__ = "GIT_HASH"

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ skipsdist=true
 
 [gh-actions]
 python =
-    3.6: py36-unit
     3.7: py37-unit
     3.8: py38-unit, lint
     3.9: py39-unit


### PR DESCRIPTION
Python3.6 was already EOL'd so no one should be using it. This is to update the dependancies and linters/tests so we don't test for that version anymore.

This is also required for the following [PR](https://github.com/amplify-education/terrawrap/pull/138) - implementation using features only available in 3.7+.