### PR TITLE
Fix: Update `user` declaration

### DIFF
--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -214,10 +214,7 @@ def _post_audit_info(
     )
 
     logger.info('Getpass.getuser() will be used to grab the user running path: %s', path)
-    try:
-        user = getpass.getuser()
-    except Exception:
-        user = 'System'
+    user = getpass.getuser() if getpass.getuser() else 'System'
     logger.info('Attempting to send data to Audit API: %s run by %s(%s)', path, user, status)
 
     url = (audit_api_url + AUDIT_UPDATE_PATH) if update else (audit_api_url + AUDIT_POST_PATH)

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.9.3"
+__version__ = "0.9.4"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
Small bug fix addressing this [error](https://app.datadoghq.com/logs?query=service%3Aterraform-audit-api&event=AQAAAYFDfBfHyO4qRQAAAABBWUZEZkRYX0FBQldlODVPdUJ1ZkF3QU4&index=&from_ts=1654693778665&to_ts=1654694678665&live=true) in `terraform-audit-api` caused by `_post_audit_info`. Apparently no user is being set, so reverting back to previous statement.