### PR TITLE
Fix: Update user declaration in `_post_audit_info`

### DIFF
--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -214,7 +214,10 @@ def _post_audit_info(
     )
 
     logger.info('Getpass.getuser() will be used to grab the user running path: %s', path)
-    user = getpass.getuser() if getpass.getuser() else 'System'
+    try:
+        user = getpass.getuser()
+    except Exception:
+        user = 'System'
     logger.info('Attempting to send data to Audit API: %s run by %s(%s)', path, user, status)
 
     url = (audit_api_url + AUDIT_UPDATE_PATH) if update else (audit_api_url + AUDIT_POST_PATH)

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.9.4"
+__version__ = "0.9.5"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
Should now handle any exceptions raised when getpass.getuser is called by AWS