### PR TITLE
Fix: Update Audit API if `execute command` times out

### DIFF
--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -118,6 +118,16 @@ def execute_command(
             break
 
         if time_passed >= timeout:
+            if audit_api_url and kwargs['cwd']:
+                # Call _post_audit_info again, this time to update the 'in progress' entry with new status and output
+                _post_audit_info(
+                    audit_api_url=audit_api_url,
+                    path=kwargs['cwd'],
+                    exit_code=exit_code,
+                    stdout=stdout,
+                    start_time=start_time,
+                    update=True
+                )
             raise TimeoutError(f'Timed out retrying {args} command')
 
         time_passed = jitter.backoff()

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -119,7 +119,8 @@ def execute_command(
 
         if time_passed >= timeout:
             if audit_api_url and kwargs['cwd']:
-                # Call _post_audit_info again, this time to update the 'in progress' entry with new status and output
+                # Call _post_audit_info again, this time to update the
+                # 'in progress' entry with new status and output
                 _post_audit_info(
                     audit_api_url=audit_api_url,
                     path=kwargs['cwd'],

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -122,16 +122,16 @@ def execute_command(
 
         time_passed = jitter.backoff()
 
-        if audit_api_url and kwargs['cwd']:
-            # Call _post_audit_info again, this time to update the 'in progress' entry with new status and output
-            _post_audit_info(
-                audit_api_url=audit_api_url,
-                path=kwargs['cwd'],
-                exit_code=exit_code,
-                stdout=stdout,
-                start_time=start_time,
-                update=True
-            )
+    if audit_api_url and kwargs['cwd']:
+        # Call _post_audit_info again, this time to update the 'in progress' entry with new status and output
+        _post_audit_info(
+            audit_api_url=audit_api_url,
+            path=kwargs['cwd'],
+            exit_code=exit_code,
+            stdout=stdout,
+            start_time=start_time,
+            update=True
+        )
 
     if time_passed >= timeout:
         raise TimeoutError(f'Timed out retrying {args} command')

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -118,33 +118,25 @@ def execute_command(
             break
 
         if time_passed >= timeout:
-            if audit_api_url and kwargs['cwd']:
-                # Call _post_audit_info again, this time to update the
-                # 'in progress' entry with new status and output
-                _post_audit_info(
-                    audit_api_url=audit_api_url,
-                    path=kwargs['cwd'],
-                    exit_code=exit_code,
-                    stdout=stdout,
-                    start_time=start_time,
-                    update=True
-                )
-            raise TimeoutError(f'Timed out retrying {args} command')
+            break
 
         time_passed = jitter.backoff()
 
-    if audit_api_url and kwargs['cwd']:
-        # Call _post_audit_info again, this time to update the 'in progress' entry with new status and output
-        _post_audit_info(
-            audit_api_url=audit_api_url,
-            path=kwargs['cwd'],
-            exit_code=exit_code,
-            stdout=stdout,
-            start_time=start_time,
-            update=True
-        )
+        if audit_api_url and kwargs['cwd']:
+            # Call _post_audit_info again, this time to update the 'in progress' entry with new status and output
+            _post_audit_info(
+                audit_api_url=audit_api_url,
+                path=kwargs['cwd'],
+                exit_code=exit_code,
+                stdout=stdout,
+                start_time=start_time,
+                update=True
+            )
 
-    return exit_code, stdout
+        if time_passed >= timeout:
+            raise TimeoutError(f'Timed out retrying {args} command')
+
+        return exit_code, stdout
 
 
 def _execute_command(

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -133,10 +133,10 @@ def execute_command(
                 update=True
             )
 
-        if time_passed >= timeout:
-            raise TimeoutError(f'Timed out retrying {args} command')
+    if time_passed >= timeout:
+        raise TimeoutError(f'Timed out retrying {args} command')
 
-        return exit_code, stdout
+    return exit_code, stdout
 
 
 def _execute_command(

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.9.6"
+__version__ = "0.9.7"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
Minor fix - making sure that `execute_command` updates the entry in `terraform-audit-api` even if there is a timeout error.