### PR TITLE
Update terrawrap to use IAM auth when calling `TF Audit API`

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -1,6 +1,7 @@
 # Place dependencies in this file, following the distutils format:
 # http://docs.python.org/2/distutils/setupscript.html#relationships-between-distributions-and-packages
 amplify-aws-utils>=0.1.2
+aws-requests-auth==0.4.3
 docopt==0.6.2
 filelock>=3.0.12,<4
 gitpython>=2.1.10

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -13,7 +13,7 @@ from typing import List, Tuple, Union
 import requests
 
 from amplify_aws_utils.resource_helper import Jitter
-from aws_requests_auth.aws_auth import AWSRequestsAuth
+from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
 
 from terrawrap.utils.git_utils import get_git_root
 
@@ -230,12 +230,10 @@ def _post_audit_info(
 
     url = (audit_api_url + AUDIT_UPDATE_PATH) if update else (audit_api_url + AUDIT_POST_PATH)
 
-    auth = AWSRequestsAuth(
-        aws_access_key='',
-        aws_secret_access_key='',
-        aws_host='',
-        aws_region='',
-        aws_service=''
+    auth = BotoAWSRequestsAuth(
+        aws_host='terraform-audit-api.devops.amplify.com',
+        aws_region='us-west-2',
+        aws_service='execute-api'
     )
 
     try:

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -13,6 +13,7 @@ from typing import List, Tuple, Union
 import requests
 
 from amplify_aws_utils.resource_helper import Jitter
+from aws_requests_auth.aws_auth import AWSRequestsAuth
 
 from terrawrap.utils.git_utils import get_git_root
 
@@ -229,15 +230,26 @@ def _post_audit_info(
 
     url = (audit_api_url + AUDIT_UPDATE_PATH) if update else (audit_api_url + AUDIT_POST_PATH)
 
+    auth = AWSRequestsAuth(
+        aws_access_key='',
+        aws_secret_access_key='',
+        aws_host='',
+        aws_region='',
+        aws_service=''
+    )
+
     try:
         requests.post(
-            url, json={
+            url=url,
+            auth=auth,
+            json={
                 'directory': path,
                 'start_time': start_time,
                 'status': status,
                 'run_by': user,
                 'output': stdout
-            })
+            }
+        )
         logger.info('Successfully posted data to provided url: %s', audit_api_url)
     except requests.exceptions.RequestException:
         logger.error("Unable to post data to provided url: %s", audit_api_url)

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.9.8"
+__version__ = "0.9.9"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -2,8 +2,7 @@
 import os
 from unittest import TestCase
 
-from mock import patch
-
+from mock import patch, ANY
 
 from terrawrap.utils.cli import execute_command, MAX_RETRIES, Status, _post_audit_info
 
@@ -93,7 +92,8 @@ class TestCli(TestCase):
             )
 
             mock_post.assert_called_with(
-                'foo.bar/audit_info',
+                url='foo.bar/audit_info',
+                auth=ANY,
                 json={
                     'directory': '/test/helpers/mock_directory/config/.tf_wrapper',
                     'start_time': 12345,


### PR DESCRIPTION
Add `AWSRequestsAuth` to terrawrap when calling API. Based on new `ResourcePolicy` in `TF Audit API` defined in this [PR](https://github.com/amplify-education/terraform-audit-api/pull/16).