### PR TITLE
Fix: Update TF Audit API post request body

### DIFF
--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -245,7 +245,7 @@ def _post_audit_info(
                 'start_time': start_time,
                 'status': status,
                 'run_by': user,
-                'output': stdout
+                'output': stdout if stdout else ''
             }
         )
         logger.info('Successfully posted data to provided url: %s', audit_api_url)

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -245,7 +245,7 @@ def _post_audit_info(
                 'start_time': start_time,
                 'status': status,
                 'run_by': user,
-                'output': stdout if stdout else ''
+                'output': stdout or ''
             }
         )
         logger.info('Successfully posted data to provided url: %s', audit_api_url)

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.9.9"
+__version__ = "0.9.10"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -99,6 +99,6 @@ class TestCli(TestCase):
                     'start_time': 12345,
                     'status': status,
                     'run_by': 'mockuser',
-                    'output': None
+                    'output': ''
                 }
             )


### PR DESCRIPTION
Quick fix - Addressing this recurring [error](https://app.datadoghq.com/logs?query=service%3Aterraform-audit-api&event=AQAAAYHTt7sLylccHQAAAABBWUhUdDl2OEFBRHBDWng3bWZsR0xnQVY&index=&from_ts=1657100204428&to_ts=1657114604428&live=true) in `TF Audit API`. Previously was posting an element with `None` type causing a serialization error on the API end. 