### PR TITLE
AT 6802 | Remove `run_by` parameter from `_post_audit_info`

### DIFF
--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -221,12 +221,7 @@ def _post_audit_info(
         Status.SUCCESS if exit_code == 0 else Status.FAILED
     )
 
-    try:
-        user = getpass.getuser()
-    except Exception:
-        user = 'System'
-
-    logger.info('Attempting to send data to Audit API: %s run by %s(%s)', path, user, status)
+    logger.info('Attempting to send data to Audit API: %s - %s', path, status)
 
     url = (audit_api_url + AUDIT_UPDATE_PATH) if update else (audit_api_url + AUDIT_POST_PATH)
 
@@ -244,7 +239,6 @@ def _post_audit_info(
                 'directory': path,
                 'start_time': start_time,
                 'status': status,
-                'run_by': user,
                 'output': stdout or ''
             }
         )

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -1,7 +1,6 @@
 """Module for containing CLI convenience functions"""
 from __future__ import print_function
 
-import getpass
 import logging
 import subprocess
 import tempfile

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.9.11"
+__version__ = "0.9.12"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -69,9 +69,8 @@ class TestCli(TestCase):
         self.assertEqual(exit_code, 255)
         self.assertEqual(stdout, [])
 
-    @patch('getpass.getuser')
     @patch('requests.post')
-    def test_post_audit_info_statuses(self, mock_post, mock_getuser_func):
+    def test_post_audit_info_statuses(self, mock_post):
         """Test Audit API helper function for each possible status"""
         statuses = {
             Status.IN_PROGRESS: None,
@@ -79,7 +78,6 @@ class TestCli(TestCase):
             Status.SUCCESS: 0
         }
 
-        mock_getuser_func.return_value = 'mockuser'
         fake_url = 'foo.bar'
         os.chdir(os.path.normpath(os.path.dirname(__file__) + '/../helpers'))
 
@@ -98,7 +96,6 @@ class TestCli(TestCase):
                     'directory': '/test/helpers/mock_directory/config/.tf_wrapper',
                     'start_time': 12345,
                     'status': status,
-                    'run_by': 'mockuser',
                     'output': ''
                 }
             )


### PR DESCRIPTION
Depends on this [PR](https://github.com/amplify-education/terraform-audit-api/pull/18)

Removing the no longer needed parameter run_by from the TF Audit API call in terrawrap.