### PR TITLE
Update TF Audit API `start_time` field

### DIFF
--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -84,7 +84,7 @@ def execute_command(
         }
 
     # Get time - nanoseconds since epoch
-    start_time = time.time_ns()
+    start_time = time.time_ns() / 1000
 
     if audit_api_url and kwargs['cwd']:
         # Call _post_audit_info for working directory, setting status to 'in progress'

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -84,7 +84,7 @@ def execute_command(
         }
 
     # Get time - nanoseconds since epoch
-    start_time = time.time_ns() / 1000
+    start_time = int(time.time())
 
     if audit_api_url and kwargs['cwd']:
         # Call _post_audit_info for working directory, setting status to 'in progress'

--- a/terrawrap/utils/plugin_download.py
+++ b/terrawrap/utils/plugin_download.py
@@ -62,7 +62,7 @@ class PluginDownload:
         etag = None
         etag_path = f'{file_path}.{"etag"}'
         if os.path.isfile(etag_path) and os.path.isfile(file_path):
-            with(open(etag_path, 'r', encoding='utf-8')) as etag_file:
+            with (open(etag_path, 'r', encoding='utf-8')) as etag_file:
                 etag = etag_file.read()
 
         download_info = self._get_file_content(url, etag)
@@ -71,7 +71,7 @@ class PluginDownload:
             content = download_info[0]
             etag = download_info[1]
 
-            with(open(file_path, 'wb', encoding='utf-8')) as out_file:
+            with (open(file_path, 'wb', encoding='utf-8')) as out_file:
                 out_file.write(content)
 
             mode = os.stat(file_path)
@@ -82,7 +82,7 @@ class PluginDownload:
                 # remove them if that happens
                 if etag[0] == '"':
                     etag = etag[1:-1]
-                with(open(etag_path, 'w', encoding='utf-8')) as etag_file:
+                with (open(etag_path, 'w', encoding='utf-8')) as etag_file:
                     etag_file.write(etag)
 
     def _get_file_content(self, url: str, etag: Optional[str]) -> Optional[Tuple[bytes, Optional[str]]]:

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.9.12"
+__version__ = "0.9.13"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_plugin_download.py
+++ b/test/unit/test_plugin_download.py
@@ -75,7 +75,7 @@ class TestPluginDownload(TestCase):
     @patch('platform.machine', MagicMock(return_value='x86_42'))
     def test_download_plugins(self):
         """Test downloading plugins"""
-        with(patch.object(self.plugin_download, '_download_file')) as download_file_mock:
+        with (patch.object(self.plugin_download, '_download_file')) as download_file_mock:
             self.plugin_download.download_plugins({
                 'foo': 'http://example.com'
             })
@@ -92,7 +92,7 @@ class TestPluginDownload(TestCase):
     @patch('platform.machine', MagicMock(return_value='x86_42'))
     def test_download_plugins_platform_missing(self):
         """Test downloading plugins and falling back to non-platform specific files"""
-        with(patch.object(self.plugin_download, '_download_file')) as download_file_mock:
+        with (patch.object(self.plugin_download, '_download_file')) as download_file_mock:
             def _download_mock_side_effect(url, _):
                 if url != 'http://example.com':
                     raise FileDownloadFailed()


### PR DESCRIPTION
Converting from milliseconds to seconds - addressing this [issue](https://app.datadoghq.com/logs?query=application%3Aterraform-audit-api&cols=host%2Cservice&event=AQAAAYJZqfQLRzkNVgAAAABBWUpacWkyRkFBQnpheUZIa1pKTzVBQUc&index=&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1659354401649&to_ts=1659368801649&live=true) where the `start_time` value is rounded since it is too large