### PR TITLE
Fix TF Audit interaction

### DIFF
--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -86,7 +86,7 @@ def execute_command(
     # Get time - nanoseconds since epoch
     start_time = int(time.time())
 
-    if audit_api_url and kwargs['cwd']:
+    if audit_api_url and kwargs['cwd'] and 'apply' in args:
         # Call _post_audit_info for working directory, setting status to 'in progress'
         _post_audit_info(
             audit_api_url=audit_api_url,
@@ -124,7 +124,7 @@ def execute_command(
 
         time_passed = jitter.backoff()
 
-    if audit_api_url and kwargs['cwd']:
+    if audit_api_url and kwargs['cwd'] and 'apply' in args:
         # Call _post_audit_info again, this time to update the 'in progress' entry with new status and output
         _post_audit_info(
             audit_api_url=audit_api_url,

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.9.14"
+__version__ = "0.9.15"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
Updating terrawrap so it only sends data to TF Audit API for `apply` runs (not `init` or `plan`).