### PR TITLE
Fix: Quick Change to Fix Auto Unlock

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -7,9 +7,6 @@
 # pygtk.require().
 #init-hook=
 
-# Profiled execution.
-profile=no
-
 # Add <file or directory> to the black list. It should be a base name, not a
 # path. You may set this option multiple times.
 ignore=CVS
@@ -52,7 +49,7 @@ load-plugins=
 # E1103: %s %r has no %r member (but some types could not be inferred) - fails to infer real members of types, e.g. in Celery
 # W0231: method from base class is not called - complains about not invoking empty __init__s in parents, which is annoying
 # R0921: abstract class not referenced, when in fact referenced from another egg
-disable=F0401,E0611,E1101,W0142,W0212,R0201,W0703,R0801,R0901,W0511,E1103,W0231,R0921
+disable=F0401,E0611,E1101,W0212,W0703,R0801,R0901,W0511,E1103,W0231
 
 
 [REPORTS]
@@ -60,14 +57,6 @@ disable=F0401,E0611,E1101,W0142,W0212,R0201,W0703,R0801,R0901,W0511,E1103,W0231,
 # Set the output format. Available formats are text, parseable, colorized, msvs
 # (visual studio) and html
 output-format=colorized
-
-# Include message's id in output
-include-ids=yes
-
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]".
-files-output=no
 
 # Tells whether to display a full report or only the messages
 reports=no
@@ -79,19 +68,8 @@ reports=no
 # (R0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
-# Add a comment according to your evaluation note. This is used by the global
-# evaluation report (R0004).
-comment=no
-
 
 [BASIC]
-
-# Required attributes for module, separated by a comma
-required-attributes=
-
-# List of builtins function names that should not be used, separated by a comma
-# Amplify: Allowing the use of 'map' and 'filter'
-bad-functions=apply,input
 
 # Regular expression which should only match correct module names
 module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
@@ -179,10 +157,6 @@ ignore-mixin-members=yes
 # (useful for classes with attributes dynamically set).
 ignored-classes=SQLObject
 
-# When zope mode is activated, add a predefined set of Zope acquired attributes
-# to generated-members.
-zope=no
-
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E0201 when accessed.
 generated-members=REQUEST,acl_users,aq_parent
@@ -203,10 +177,6 @@ additional-builtins=
 
 [CLASSES]
 
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
-
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp
 
@@ -225,9 +195,6 @@ max-locals=16
 
 # Maximum number of return / yield for function / method body
 max-returns=6
-
-# Maximum number of branch for function / method body
-max-branchs=12
 
 # Maximum number of statements in function / method body
 max-statements=50

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -240,7 +240,8 @@ def _post_audit_info(
                 'start_time': start_time,
                 'status': status,
                 'output': stdout_str
-            }
+            },
+            timeout=30,
         )
         logger.info('Successfully posted data to provided url: %s', audit_api_url)
     except requests.exceptions.RequestException:

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -34,7 +34,6 @@ RETRIABLE_ERRORS = [
     'try again later',
     'handshake timeout',
     'SSL_ERROR_SYSCALL',
-    'ConditionalCheckFailedException',
     'Api Rate Limit Exceeded',
     'TooManyUpdates',
 ]

--- a/terrawrap/utils/plugin_download.py
+++ b/terrawrap/utils/plugin_download.py
@@ -114,7 +114,7 @@ class PluginDownload:
             headers['If-None-Match'] = etag
 
         try:
-            response = requests.get(url, headers=headers)
+            response = requests.get(url, headers=headers, timeout=5)
             response.raise_for_status()
 
             if response.status_code == 304:

--- a/terrawrap/utils/version.py
+++ b/terrawrap/utils/version.py
@@ -49,5 +49,5 @@ def get_latest_version(current_version: str) -> str:
     :param current_version: The current version of Terrawrap.
     :return: The latest version of Terrawrap, potentially delayed by one day.
     """
-    response = requests.get("https://pypi.python.org/pypi/terrawrap/json").json()
+    response = requests.get("https://pypi.python.org/pypi/terrawrap/json", timeout=5).json()
     return response["info"]["version"]

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.9.15"
+__version__ = "0.9.16"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -97,5 +97,6 @@ class TestCli(TestCase):
                     'start_time': 12345,
                     'status': status,
                     'output': ''
-                }
+                },
+                timeout=30,
             )


### PR DESCRIPTION
This error string sppears in the unable to acquire state lock error message, and network errors superseed state lock errors, so graph apply could end up in an infinite loop retrying the directory until the creds expired.