### PR TITLE
Feat: Add SCPs to Plan Check

### DIFF
--- a/bin/plan_check
+++ b/bin/plan_check
@@ -43,7 +43,7 @@ from terrawrap.utils.tf_variables import get_auto_var_usage_graph
 from networkx import compose_all, descendants
 
 TERRAFORM_PERFORM_ACTIONS = "Terraform will perform the following actions"
-IAM_POLICY_RE = re.compile('[-~+] .*(aws_iam_|aws_s3_bucket_policy).*')
+IAM_POLICY_RE = re.compile('[-~+] .*(aws_iam_|aws_s3_bucket_policy|aws_organizations_policy).*')
 SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
 CURRENT_DIRECTORY = os.getcwd()
 

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.9.16"
+__version__ = "0.9.17"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
SCPs are essentially IAM policies that get applied across accounts, so we should treat them like IAM resources in terms of requiring additional approvals.