### PR TITLE
AT 7319 | Add commit hash to audit handling

### DIFF
--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -14,7 +14,7 @@ import requests
 from amplify_aws_utils.resource_helper import Jitter
 from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
 
-from terrawrap.utils.git_utils import get_git_root
+from terrawrap.utils.git_utils import get_git_root, get_git_hash
 
 logger = logging.getLogger(__name__)
 
@@ -213,6 +213,8 @@ def _post_audit_info(
         update: bool = False
 ):
     root = get_git_root(path)
+    sha = get_git_hash(path)
+
     path = path.replace(root, '')
 
     status = Status.IN_PROGRESS if exit_code is None else (
@@ -239,7 +241,8 @@ def _post_audit_info(
                 'directory': path,
                 'start_time': start_time,
                 'status': status,
-                'output': stdout_str
+                'output': stdout_str,
+                'git_hash': sha
             },
             timeout=30,
         )

--- a/terrawrap/utils/git_utils.py
+++ b/terrawrap/utils/git_utils.py
@@ -27,3 +27,10 @@ def get_git_root(path):
     git_repo = Repo(path, search_parent_directories=True)
     git_root = git_repo.git.rev_parse("--show-toplevel")
     return git_root
+
+
+def get_git_hash(path):
+    """Get the git hash for tf apply run changes"""
+    repo = Repo(path, search_parent_directories=True)
+    sha = repo.head.object.hexsha
+    return sha


### PR DESCRIPTION
Quick PR - adding some functionality to get the commit hash and send it to TF Audit API. 