### PR TITLE
Change plan_check --modified-only to diff against merge base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -   Change `--modified-only` behavior of `plan_check` command. `--modified-only` will now compare with `merge-base`
     using `git merge-base` command instead of directly comparing against the master branch
 
-
 ## [0.9.19] - 2022-09-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Change `--modified-only` behavior of `plan_check` command. `--modified-only` will now compare with `merge-base`
-  using `git merge-base` command instead of directly comparing against the master branch
+-   Change `--modified-only` behavior of `plan_check` command. `--modified-only` will now compare with `merge-base`
+    using `git merge-base` command instead of directly comparing against the master branch
 
 
 ## [0.9.19] - 2022-09-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -   Terraform provider version lock files are not automatically deleted
 
-
 ## [0.8.0] - 2021-02-11
 
 ### Changed
@@ -80,7 +79,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 -   Fixed a bug in `graph_apply` when there are symlinks to directories above the directory being applied
-
 
 ## [0.6.15] - 2020-12-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.9.20] - 2022-09-23
+
+### Changed
+
+- Change `--modified-only` behavior of `plan_check` command. `--modified-only` will now compare with `merge-base`
+  using `git merge-base` command instead of directly comparing against the master branch
+
+
 ## [0.9.19] - 2022-09-21
 
 ### Changed

--- a/terrawrap/utils/git_utils.py
+++ b/terrawrap/utils/git_utils.py
@@ -13,7 +13,20 @@ def get_git_changed_files(path) -> Set[str]:
     """
     repo = Repo(path, search_parent_directories=True)
     changed_files = set()
-    for change in repo.commit('origin/master').diff(None):
+
+    # Get the common ancestor commit between master and HEAD
+    # See https://git-scm.com/docs/git-merge-base
+    # then compare the current working directory with the common ancestor
+    # We do it this way so that we don't get extra diffs in cases when master is ahead of our branch.
+    # if we compared the current branch directly with master then we would see changes on master that
+    # haven't been merged into our branch yet.
+    merge_base = repo.merge_base("origin/master", "HEAD")
+    if merge_base and merge_base[0] is not None:
+        base_commit = merge_base[0]
+    else:
+        base_commit = repo.commit('origin/master')
+
+    for change in base_commit.diff():
         if not change.new_file:
             changed_files.add(os.path.abspath(change.a_path))
         if not change.deleted_file:

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.9.19"
+__version__ = "0.9.20"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_git.py
+++ b/test/unit/test_git.py
@@ -14,7 +14,7 @@ class TestGit(TestCase):
     @patch('terrawrap.utils.git_utils.Repo')
     def test_get_git_changed_files(self, repo):
         """Test getting list of changed files in git"""
-        repo.return_value.commit.return_value.diff.return_value = [
+        repo.return_value.merge_base.return_value[0].diff.return_value = [
             Change('/foo', '/foo', False, False),
             Change(None, '/bar', True, False),
             Change('/baz', None, False, True)

--- a/test/unit/test_version.py
+++ b/test/unit/test_version.py
@@ -69,6 +69,7 @@ class TestVersion(TestCase):
         )
 
     @patch("requests.get")
+    @patch("terrawrap.utils.version.Cache", MagicMock())
     def test_get_latest_version_happy(self, mock_get):
         """VersionUtils get latest version happy path"""
         current_version = "1.0.0"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist=lint,{py36,py37,py38,py39}-unit
 skipsdist=true
 
 [gh-actions]


### PR DESCRIPTION
Use merge base when calculating diff against master to avoid including extraneous changes.

Also remove python3.6 from tox config. We dropped support for python3.6 some time ago