### PR TITLE
Add support for assuming roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2022-10-11
+
+### Added
+
+-   Added support to assume a different role when running the `tf` command. A new `assume_role` block is now available
+    in `.tf_wrapper` config files with `account_id`, `role_name` and `for_commands` options. `account_id` and `role_name` 
+    are required and are used to specify which role should be assumed. `for_commands` is an optional list of `terraform`
+    commands (such as `plan`, `apply`, `init`, etc) which should be run with an assumed role.
+
 ## [0.9.20] - 2022-09-23
 
 ### Changed

--- a/bin/tf
+++ b/bin/tf
@@ -28,6 +28,8 @@ from typing import List, Dict, Tuple
 
 import boto3
 
+from amplify_aws_utils.clients.sts import STS
+
 from terrawrap.utils.cli import execute_command
 from terrawrap.utils.config import (
     find_variable_files,
@@ -275,6 +277,20 @@ def handler():
                 existing_backend_config=existing_backend_config
             )
             additional_arguments = backend_config + additional_arguments
+
+    if wrapper_config.assume_role:
+        role_config = wrapper_config.assume_role
+        if command in role_config.for_commands:
+            print(f"Assuming role '{role_config.role_name}' in account '{role_config.account_id}'")
+            sts = STS(boto3.client('sts'))
+            creds = sts.assume_role(
+                account_id=role_config.account_id,
+                role_name=role_config.role_name,
+            )
+
+            additional_envvars["AWS_ACCESS_KEY_ID"] = creds["AccessKeyId"]
+            additional_envvars["AWS_SECRET_ACCESS_KEY"] = creds["SecretAccessKey"]
+            additional_envvars["AWS_SESSION_TOKEN"] = creds["SessionToken"]
 
     if command == "init":
         plugin_download = PluginDownload(boto3.client('s3'))

--- a/terrawrap/models/wrapper_config.py
+++ b/terrawrap/models/wrapper_config.py
@@ -62,6 +62,13 @@ class BackendsConfig:
         self.gcs = gcs
 
 
+class AssumeRoleConfig:
+    def __init__(self, account_id: str, role_name: str, for_commands: List[str] = None):
+        self.account_id = account_id
+        self.role_name = role_name
+        self.for_commands = for_commands or []
+
+
 # pylint: disable=unused-argument
 def env_var_deserializer(obj_dict, cls, **kwargs):
     """convert a dict to a subclass of AbstractEnvVarConfig"""
@@ -92,7 +99,8 @@ class WrapperConfig:
             config: bool = True,
             audit_api_url: str = None,
             apply_automatically: bool = True,
-            plugins: Dict[str, str] = None
+            plugins: Dict[str, str] = None,
+            assume_role: AssumeRoleConfig = None
     ):
         self.configure_backend = configure_backend
         self.pipeline_check = pipeline_check
@@ -105,3 +113,4 @@ class WrapperConfig:
         self.audit_api_url = audit_api_url
         self.apply_automatically = apply_automatically
         self.plugins = plugins or {}
+        self.assume_role = assume_role

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.9.20"
+__version__ = "0.10.0"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
This adds new options to .tf_wrapper config files for assuming roles before running Terraform commands. terrawrap will assume the given role and then pass in AWS credentials