### PR TITLE
Remove `TF Audit` calls from graph_entry

### DIFF
--- a/terrawrap/models/graph_entry.py
+++ b/terrawrap/models/graph_entry.py
@@ -80,7 +80,6 @@ class GraphEntry(Entry):
             print_output=False,
             capture_stderr=True,
             env=command_env,
-            audit_api_url=self.wrapper_config.audit_api_url,
             cwd=self.abs_path
         )
         if init_exit_code != 0:
@@ -98,7 +97,6 @@ class GraphEntry(Entry):
             capture_stderr=True,
             env=command_env,
             shell=shell,
-            audit_api_url=self.wrapper_config.audit_api_url,
             cwd=self.path
         )
 

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.9.20"
+__version__ = "0.9.21"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
There's an issue with how `terrawrap` and `TF Audit` that causes duplicate apply data to be stored (see [example](https://tfaudit.devops.amplify.com/history/+config+aws+litco-dev+us-west-2+ci+mclass+ras-autotests+rasberi-export-pdf-autotests)). 

I intended on rewriting parts of terrawrap to address this, but turns out removing the interaction between the API and terrawrap inside `graph_entry.py` should do the trick.