### PR TITLE
[BugFix] make regex pattern for matching lock create time up to microseconds

### DIFF
--- a/bin/tf
+++ b/bin/tf
@@ -147,7 +147,7 @@ def tf_unlock(error: str, path: str, lock_timeout: timedelta) -> bool:
     # strptime can handle microseconds, not nanoseconds
     # utcnow object does not have offset and timezone name
     # Strip last 13 characters from lock creation time
-    created_time = re.search(r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d+', error).group()
+    created_time = re.search(r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{1,6}', error).group()
     delta = datetime.utcnow() - datetime.strptime(created_time, '%Y-%m-%d %H:%M:%S.%f')
     if delta > lock_timeout:
         exit_code, output = execute_command(

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.9.22"
+__version__ = "0.9.23"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
They always used nanoseconds, thus the comment in the code 
```
    # strptime can handle microseconds, not nanoseconds
    # utcnow object does not have offset and timezone name
    # Strip last 13 characters from lock creation time
```