### PR TITLE
AT-10360 No Longer Delete Terraform Lock Files

### DIFF
--- a/bin/tf
+++ b/bin/tf
@@ -101,9 +101,6 @@ def exec_tf_command(
 
     if command == "init":
         shutil.rmtree(os.path.join(path, ".terraform"), ignore_errors=True)
-        lock_file_path = os.path.join(path, ".terraform.lock.hcl")
-        if os.path.exists(lock_file_path):
-            os.remove(lock_file_path)
 
     if command == "import":
         response = input(

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.9.27"
+__version__ = "0.9.28"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
We're going to start using these in our environment, so no longer automatically delete them.