### PR TITLE
utils/path.py - fix `GIT_REPO_REGEX` and `calc_repo_path`

### DIFF
--- a/terrawrap/utils/path.py
+++ b/terrawrap/utils/path.py
@@ -7,7 +7,7 @@ from typing import Dict, Set
 
 from networkx import DiGraph
 
-GIT_REPO_REGEX = r"URL.*/([\w-]*)(?:\.git)?"
+GIT_REPO_REGEX = r"(URL)?.*/([\w-]*)(?:\.git)?"
 
 
 def get_absolute_path(path: str, root_dir: str = None) -> str:
@@ -108,7 +108,7 @@ def calc_repo_path(path: str) -> str:
     output = byte_output.decode("utf-8", errors="replace")
     match = re.search(GIT_REPO_REGEX, output)
     if match:
-        repo_name = match.group(1)
+        repo_name = match.group(2)
     else:
         raise RuntimeError("Could not determine git repo name, are we in a git repo?")
 

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.9.30"
+__version__ = "0.9.31"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_path.py
+++ b/test/unit/test_path.py
@@ -1,10 +1,11 @@
 """Test path utilities"""
 import os
 from unittest import TestCase
+from unittest.mock import patch, MagicMock
 
 from networkx import DiGraph
 
-from terrawrap.utils.path import get_file_graph
+from terrawrap.utils.path import get_file_graph, calc_repo_path
 
 
 class TestPath(TestCase):
@@ -64,3 +65,22 @@ class TestPath(TestCase):
         )
         self.assertEqual(set(actual.nodes), set(expected.nodes))
         self.assertEqual(set(actual.edges), set(expected.edges))
+
+    @patch("terrawrap.utils.path.subprocess.check_output")
+    def test_calc_repo_path(self, check_output_mock: MagicMock):
+        """test getting repo path based on repo remote"""
+        check_output_mock.return_value = b"git@github.com:amplify-education/repo-1.git"
+        result = calc_repo_path("path/config")
+        self.assertEqual(result, "repo-1/config")
+
+        check_output_mock.return_value = (
+            b"https://github.com/amplify-education/repo-2.git"
+        )
+        result = calc_repo_path("path/config")
+        self.assertEqual(result, "repo-2/config")
+
+        check_output_mock.return_value = (
+            b"Fetch URL: https://github.com/amplify-education/repo-3.git"
+        )
+        result = calc_repo_path("path/config")
+        self.assertEqual(result, "repo-3/config")


### PR DESCRIPTION
When running `tf init`, terrawrap wasn't able to match regex to my remotes (both SSH and HTTPS). 
Turns out my git installation is translated to polish, so `git remote show origin -n` shows
`Adres do pobierania: https://github.com/amplify-education/terraform-config.git`
instead of
`Fetch URL https://github.com/amplify-education/terraform-config.git`
The regex is looking for the `URL` phrase which is absent in my case, hence the issue.