### PR TITLE
Always Upgrade on Init

### DIFF
--- a/terrawrap/utils/config.py
+++ b/terrawrap/utils/config.py
@@ -309,7 +309,7 @@ def calc_backend_config(
     :return: A dictionary representing the backend configuration for the Terraform directory.
     """
 
-    backend_config = ["-reconfigure"]
+    backend_config = ["-reconfigure", "-upgrade"]
     options: Dict[str, str] = {}
     repo_path = calc_repo_path(path=path)
 

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -157,6 +157,7 @@ class TestConfig(TestCase):
 
         expected_config = [
             "-reconfigure",
+            "-upgrade",
             (f"-backend-config=dynamodb_table={LOCK_TABLE}"),
             "-backend-config=encrypt=true",
             "-backend-config=key=terrawrap/config/app1.tfstate",
@@ -183,6 +184,7 @@ class TestConfig(TestCase):
 
         expected_config = [
             "-reconfigure",
+            "-upgrade",
             f"-backend-config=dynamodb_table={LOCK_TABLE}",
             "-backend-config=encrypt=true",
             "-backend-config=key=terrawrap/config/app1.tfstate",
@@ -211,6 +213,7 @@ class TestConfig(TestCase):
 
         expected_config = [
             "-reconfigure",
+            "-upgrade",
             f"-backend-config=dynamodb_table={LOCK_TABLE}",
             "-backend-config=encrypt=true",
             "-backend-config=key=terrawrap/config/app1.tfstate",


### PR DESCRIPTION
Now that we encourage people to fix to a specific version of plugins,
this will make the upgrade process easier by automatically pulling in
the new version when they init the directory.