### PR TITLE
make `version_check` and publish job rc-aware

### DIFF
--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -36,6 +36,12 @@ jobs:
       - uses: actions/checkout@master
         with:
           fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - name: Install packaging
+        run: pip install packaging
       - name: Check version updated
         run: bash bin/versionCheck.sh ${GITHUB_BASE_REF##*/} "true"
 

--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - rc/*
   pull_request:
     types:
       - opened
@@ -49,7 +50,7 @@ jobs:
     name: Build and publish Python distributions
     runs-on: github-hosted-static-ip
     needs: [test]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/rc/')
     steps:
       - uses: actions/checkout@master
       - name: Set up Python

--- a/bin/versionCheck.sh
+++ b/bin/versionCheck.sh
@@ -20,10 +20,8 @@ if [ "$IS_PULL_REQUEST" != "false" ]; then
         FAILURE_REASON="Failure reason: Version number should be bumped."
     fi
 
-    HIGHEST_VERSION=$(echo -e "$CURRENT_VERSION\n$NEW_VERSION" | sort --version-sort | tail -n 1)
-
-    if [ "$HIGHEST_VERSION" != "$NEW_VERSION" ]; then
-        FAILURE_REASON="Failure Reason: New version ($NEW_VERSION) is less than current version ($HIGHEST_VERSION)"
+    if ! python3 -c "from packaging.version import parse; exit(0 if parse('$NEW_VERSION') > parse('$CURRENT_VERSION') else 1)"; then
+        FAILURE_REASON="Failure Reason: New version ($NEW_VERSION) is not greater than current version ($CURRENT_VERSION)"
     fi
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 # Place dependencies in this file, following the distutils format:
 # http://docs.python.org/2/distutils/setupscript.html#relationships-between-distributions-and-packages
--r test-requirements.txt
-
 amplify-aws-utils>=0.5.1
 aws-requests-auth==0.4.3
 docopt==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 # Place dependencies in this file, following the distutils format:
 # http://docs.python.org/2/distutils/setupscript.html#relationships-between-distributions-and-packages
+-r test-requirements.txt
+
 amplify-aws-utils>=0.5.1
 aws-requests-auth==0.4.3
 docopt==0.6.2

--- a/terrawrap/utils/version.py
+++ b/terrawrap/utils/version.py
@@ -3,14 +3,19 @@ import sys
 import tempfile
 import os
 from time import sleep
+from typing import Optional, Tuple
 
 import requests
 from packaging import version
 from diskcache import Cache
 
+from terrawrap.version import __version__
+
 
 ONE_DAY_IN_SECONDS = 60 * 60 * 24
-cache = Cache(os.path.join(tempfile.gettempdir(), "terrawrap_version_cache"))
+cache = Cache(
+    os.path.join(tempfile.gettempdir(), f"terrawrap_version_cache_{__version__}")
+)
 
 
 def version_check(current_version: str) -> bool:
@@ -20,19 +25,31 @@ def version_check(current_version: str) -> bool:
     :return: True if the version of Terrawrap is stale.
     """
     try:
-        latest_version = get_latest_version(current_version=current_version)
-        if version.parse(latest_version) <= version.parse(current_version):
-            return False
+        latest_stable, latest_rc = get_latest_version(current_version=current_version)
+        current = version.parse(current_version)
+        is_stale = False
 
-        print(
-            "WARNING: Your version of Terrawrap is stale!",
-            f"You have version '{current_version}' but the latest is '{latest_version}'",
-            "Please upgrade as soon as possible!\n pip install --upgrade terrawrap \n",
-            sep="\n",
-            file=sys.stderr,
-        )
-        sleep(1)
-        return True
+        if version.parse(latest_stable) > current:
+            print(
+                "WARNING: Your version of Terrawrap is stale!",
+                f"You have version '{current_version}' but the latest is '{latest_stable}'",
+                "Please upgrade as soon as possible!\n pip install --upgrade terrawrap \n",
+                sep="\n",
+                file=sys.stderr,
+            )
+            is_stale = True
+
+        if latest_rc and version.parse(latest_rc) > current:
+            print(
+                "NOTE: A release candidate latest_rc is available.",
+                f"\n f'pip install terrawrap=={latest_rc}' \n",
+                sep="",
+            )
+
+        if is_stale:
+            sleep(1)
+
+        return is_stale
     except Exception as exp:
         print(
             f"WARNING: Encountered some error while checking for latest version of Terrawrap: {repr(exp)}",
@@ -43,13 +60,19 @@ def version_check(current_version: str) -> bool:
 # We supply current_version so that the cache is invalidated when you install a new version of Terrawrap.
 # pylint: disable=unused-argument
 @cache.memoize(expire=ONE_DAY_IN_SECONDS)
-def get_latest_version(current_version: str) -> str:
+def get_latest_version(current_version: str) -> Tuple[str, Optional[str]]:
     """
-    Get the latest version of Terrawrap from Pypi. Caches this lookup for one day locally.
-    :param current_version: The current version of Terrawrap.
-    :return: The latest version of Terrawrap, potentially delayed by one day.
+    Get the latest stable and RC versions of Terrawrap from PyPI.
+    Caches this lookup for one day locally.
+    :param current_version: The current version of Terrawrap (used for cache invalidation).
+    :return: Tuple of (latest stable version, latest RC version or None).
     """
     response = requests.get(
         "https://pypi.python.org/pypi/terrawrap/json", timeout=5
     ).json()
-    return response["info"]["version"]
+    all_versions = [version.parse(v) for v in response["releases"]]
+    stable_versions = [v for v in all_versions if not v.is_prerelease]
+    rc_versions = [v for v in all_versions if v.is_prerelease]
+    latest_stable = str(max(stable_versions))
+    latest_rc = str(max(rc_versions)) if rc_versions else None
+    return latest_stable, latest_rc

--- a/terrawrap/utils/version.py
+++ b/terrawrap/utils/version.py
@@ -9,13 +9,9 @@ import requests
 from packaging import version
 from diskcache import Cache
 
-from terrawrap.version import __version__
-
 
 ONE_DAY_IN_SECONDS = 60 * 60 * 24
-cache = Cache(
-    os.path.join(tempfile.gettempdir(), f"terrawrap_version_cache_{__version__}")
-)
+cache = Cache(os.path.join(tempfile.gettempdir(), "terrawrap_version_cache"))
 
 
 def version_check(current_version: str) -> bool:
@@ -41,9 +37,10 @@ def version_check(current_version: str) -> bool:
 
         if latest_rc and version.parse(latest_rc) > current:
             print(
-                "NOTE: A release candidate latest_rc is available.",
-                f"\n f'pip install terrawrap=={latest_rc}' \n",
+                f"NOTE: A release candidate {latest_rc} is available.",
+                f"\n pip install terrawrap=={latest_rc} \n",
                 sep="",
+                file=sys.stderr,
             )
 
         if is_stale:

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.10.13"
+__version__ = "0.10.14"
 __git_hash__ = "GIT_HASH"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,5 @@
+-r requirements.txt
+
 # Linting tools
 pylint>=2.3.1,<3
 mypy>=1.10.0,<2

--- a/test/unit/test_version.py
+++ b/test/unit/test_version.py
@@ -16,43 +16,31 @@ class TestVersion(TestCase):
     def test_version_check_older(self, mock_get_latest_version):
         """VersionUtils version check with older version"""
         current_version = "1.0.0"
-        latest_version = "1.0.1"
-        mock_get_latest_version.return_value = latest_version
+        mock_get_latest_version.return_value = ("1.0.1", None)
 
         response = version_check(current_version=current_version)
 
-        self.assertEqual(
-            response,
-            True,
-        )
+        self.assertTrue(response)
 
     @patch("terrawrap.utils.version.get_latest_version")
     def test_version_check_newer(self, mock_get_latest_version):
         """VersionUtils version check with newer version"""
         current_version = "1.0.1"
-        latest_version = "1.0.0"
-        mock_get_latest_version.return_value = latest_version
+        mock_get_latest_version.return_value = ("1.0.0", None)
 
         response = version_check(current_version=current_version)
 
-        self.assertEqual(
-            response,
-            False,
-        )
+        self.assertFalse(response)
 
     @patch("terrawrap.utils.version.get_latest_version")
     def test_version_check_equal(self, mock_get_latest_version):
         """VersionUtils version check with equal version"""
         current_version = "1.0.0"
-        latest_version = "1.0.0"
-        mock_get_latest_version.return_value = latest_version
+        mock_get_latest_version.return_value = ("1.0.0", None)
 
         response = version_check(current_version=current_version)
 
-        self.assertEqual(
-            response,
-            False,
-        )
+        self.assertFalse(response)
 
     @patch("terrawrap.utils.version.get_latest_version")
     def test_version_check_handles_exception(self, mock_get_latest_version):
@@ -62,22 +50,33 @@ class TestVersion(TestCase):
 
         response = version_check(current_version=current_version)
 
-        self.assertEqual(
-            response,
-            False,
-        )
+        self.assertFalse(response)
 
     @patch("requests.get")
     @patch("terrawrap.utils.version.Cache", MagicMock())
     def test_get_latest_version_happy(self, mock_get):
-        """VersionUtils get latest version happy path"""
+        """VersionUtils get latest version returns stable and rc"""
         current_version = "1.0.0"
-        latest_version = "1.0.1"
-        mock_get.return_value.json.return_value = {"info": {"version": latest_version}}
+        mock_get.return_value.json.return_value = {
+            "releases": {"1.0.0": [], "1.0.1": [], "1.0.2rc1": []}
+        }
 
-        response = get_latest_version(current_version=current_version)
+        # pylint:disable=C0103
+        stable, rc = get_latest_version(current_version=current_version)
 
-        self.assertEqual(
-            response,
-            latest_version,
-        )
+        self.assertEqual(stable, "1.0.1")
+        self.assertEqual(rc, "1.0.2rc1")
+
+    @patch("requests.get")
+    @patch("terrawrap.utils.version.Cache", MagicMock())
+    def test_get_latest_version_no_rc(self, mock_get):
+        """VersionUtils get latest version returns None for rc when no RCs exist"""
+        current_version = "1.0.0"
+        mock_get.return_value.json.return_value = {
+            "releases": {"1.0.0": [], "1.0.1": []}
+        }
+        # pylint:disable=C0103
+        stable, rc = get_latest_version(current_version=current_version)
+
+        self.assertEqual(stable, "1.0.1")
+        self.assertIsNone(rc)

--- a/test/unit/test_version.py
+++ b/test/unit/test_version.py
@@ -43,6 +43,27 @@ class TestVersion(TestCase):
         self.assertFalse(response)
 
     @patch("terrawrap.utils.version.get_latest_version")
+    def test_version_check_rc_available(self, mock_get_latest_version):
+        """VersionUtils version check prints RC notice when RC is newer"""
+        current_version = "1.0.0"
+        mock_get_latest_version.return_value = ("1.0.0", "1.0.1rc1")
+
+        response = version_check(current_version=current_version)
+
+        self.assertFalse(response)
+
+    @patch("terrawrap.utils.version.sleep", MagicMock())
+    @patch("terrawrap.utils.version.get_latest_version")
+    def test_version_check_stale_with_rc(self, mock_get_latest_version):
+        """VersionUtils version check returns stale and shows RC when both apply"""
+        current_version = "1.0.0"
+        mock_get_latest_version.return_value = ("1.0.1", "1.0.2rc1")
+
+        response = version_check(current_version=current_version)
+
+        self.assertTrue(response)
+
+    @patch("terrawrap.utils.version.get_latest_version")
     def test_version_check_handles_exception(self, mock_get_latest_version):
         """VersionUtils version check swallows exception"""
         current_version = "1.0.0"


### PR DESCRIPTION
I would like to upgrade terrawrap's python-hcl2 dependency to [the release-candidate of new version 8](https://pypi.org/project/python-hcl2/8.0.0rc1/). 
The new version introduces full architecture overhaul, as well as new API and CLI - this means a lot of (potentially) breaking changes.

Since python-hcl2 v8 is an rc, it makes sense to release terrawrap as an rc as well, but in order to do this **we need to make this library RC-aware first**.