### PR TITLE
update python-hcl2 dependency to any v8 minor version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ gitpython>=2.1.10
 PyYAML>=6.0.1,<7
 ssm-cache>=2.7,<3
 jsons>=1.6.3,<2.0.0
-python-hcl2==8.0.0rc1
+python-hcl2~=8.1
 # Packaging does not obey semver
 packaging==26
 diskcache>=5.0.0,<6

--- a/terrawrap/utils/hcl.py
+++ b/terrawrap/utils/hcl.py
@@ -1,41 +1,32 @@
 """Utilities for loading HCL2 files with normalized output.
 
-python-hcl2 v8 preserves quotes in serialized strings and adds __is_block__ markers.
-These wrappers strip that extra formatting so the rest of the codebase can work with
-plain Python dicts and unquoted string values.
+python-hcl2 v8 preserves quotes in serialized strings and adds metadata markers.
+The below wrappers use SerializationOptions to restore v7-style behavior so the rest
+of the codebase can work with plain Python dicts and unquoted string values.
 """
-from typing import TextIO
+from typing import TextIO, Optional
 
 import hcl2
+from hcl2 import SerializationOptions
+
+_V7_COMPAT = SerializationOptions(
+    strip_string_quotes=True,
+    explicit_blocks=False,
+    with_comments=False,
+)
 
 
-def _strip_quotes(value: str) -> str:
-    """Strip surrounding double-quotes from a string if present."""
-    if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
-        return value[1:-1]
-    return value
-
-
-def _normalize(obj):
-    """Recursively normalize hcl2 v8 output to match v3-style dicts."""
-    if isinstance(obj, dict):
-        return {
-            _strip_quotes(str(k)): _normalize(v)
-            for k, v in obj.items()
-            if k != "__is_block__"
-        }
-    if isinstance(obj, list):
-        return [_normalize(item) for item in obj]
-    if isinstance(obj, str):
-        return _strip_quotes(obj)
-    return obj
-
-
-def hcl2_load(file: TextIO) -> dict:
+def hcl2_load(
+    file: TextIO, serialization_options: Optional[SerializationOptions] = None
+) -> dict:
     """Load HCL2 from a file object and return a normalized Python dict."""
-    return _normalize(hcl2.load(file))
+    serialization_options = serialization_options or _V7_COMPAT
+    return hcl2.load(file, serialization_options=serialization_options)
 
 
-def hcl2_loads(text: str) -> dict:
+def hcl2_loads(
+    text: str, serialization_options: Optional[SerializationOptions] = None
+) -> dict:
     """Load HCL2 from a string and return a normalized Python dict."""
-    return _normalize(hcl2.loads(text))
+    serialization_options = serialization_options or _V7_COMPAT
+    return hcl2.loads(text, serialization_options=serialization_options)

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.11.0rc1"
+__version__ = "0.11.0rc2"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
Also 

- simplify `terrawrap/utils/hcl.py` after `strip_string_quotes` option was added to python-hcl2
- bump version to 0.11.0rc2 for release