### PR TITLE
Compress large terraform output before posting to audit API

### DIFF
--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -1,6 +1,8 @@
 """Module for containing CLI convenience functions"""
 from __future__ import print_function
 
+import base64
+import gzip
 import logging
 import subprocess
 import tempfile
@@ -41,6 +43,7 @@ RETRIABLE_ERRORS = [
 ]
 AUDIT_POST_PATH = "/audit_info"
 AUDIT_UPDATE_PATH = "/update_audit_info"
+OUTPUT_COMPRESSION_THRESHOLD = 5 * 1024 * 1024
 
 
 class Status(str, Enum):
@@ -250,19 +253,34 @@ def _post_audit_info(
 
     stdout_str = "".join(stdout) if stdout else ""
 
+    payload = {
+        "directory": path,
+        "start_time": start_time,
+        "status": status,
+        "git_hash": sha,
+    }
+
+    if len(stdout_str) > OUTPUT_COMPRESSION_THRESHOLD:
+        compressed = gzip.compress(stdout_str.encode("utf-8"))
+        payload["output"] = ""
+        payload["output_compressed"] = base64.b64encode(compressed).decode("ascii")
+        logger.info(
+            "Compressed output for %s: %s -> %s bytes",
+            path,
+            len(stdout_str),
+            len(compressed),
+        )
+    else:
+        payload["output"] = stdout_str
+
     try:
-        requests.post(
+        response = requests.post(
             url=url,
             auth=auth,
-            json={
-                "directory": path,
-                "start_time": start_time,
-                "status": status,
-                "output": stdout_str,
-                "git_hash": sha,
-            },
+            json=payload,
             timeout=30,
         )
+        response.raise_for_status()
         logger.info("Successfully posted data to provided url: %s", audit_api_url)
     except requests.exceptions.RequestException:
         logger.error("Unable to post data to provided url: %s", audit_api_url)

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.10.15"
+__version__ = "0.10.16"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
## Summary

- Outputs > 5 MB are gzip+base64 compressed and sent as `output_compressed` instead of `output`, keeping the payload well under API Gateway's 10 MB limit
- Adds `response.raise_for_status()` so oversized or failed posts surface as errors instead of silent false successes
- No change in behavior for applies with small output

## Context

Snowflake apply output is ~12.7 MB (~87K lines). API Gateway silently returns 413, but because terrawrap never called `raise_for_status()`, it logged "Successfully posted" and moved on — leaving applies stuck IN PROGRESS forever. `config/snowflake/amplify_prod_2` has zero successful applies ever recorded for this reason.

**Deploy order:** terraform-audit-api ([PR #177](https://github.com/amplify-education/terraform-audit-api/pull/177)) must be deployed first so the API can decompress before this change sends compressed payloads.

## Test plan

- [ ] After both deploys, trigger a snowflake apply and confirm it transitions to SUCCESS in tfaudit
- [ ] Verify Datadog shows `service:terraform-audit-api "Decompressed output"` log line
- [ ] Verify small-output applies are unaffected (no compression path taken)
- [ ] Confirm `tfaudit search -d "snowflake/axiom" -s SUCCESS` shows new records

🤖 Generated with [Claude Code](https://claude.com/claude-code)