### PR TITLE
Tolerate stderr noise before JSON in plan_check

### DIFF
--- a/bin/plan_check
+++ b/bin/plan_check
@@ -42,6 +42,7 @@ from terrawrap.utils.config import (
 from terrawrap.utils.git_utils import get_git_changed_files, get_git_root
 from terrawrap.utils.module import get_module_usage_graph
 from terrawrap.utils.path import get_file_graph
+from terrawrap.utils.plan import extract_show_json
 from terrawrap.utils.tf_variables import get_auto_var_usage_graph
 
 from networkx import compose_all, descendants
@@ -117,18 +118,20 @@ def convert_plan_to_json(
         env=command_env,
     )
 
-    show_stdout = "\n".join(
-        stdout[1:]
-    )  #  the first line of `tf` output is a command itself
-
     if exit_code == PlanExitCode.FAILURE.value:
         raise RuntimeError(
-            f"'terraform show' failed for {plan_binary_file}:\n{show_stdout}"
+            f"'terraform show' failed for {plan_binary_file}:\n{''.join(stdout)}"
         )
+
+    # `tf` echoes the command and execute_command merges stderr into stdout, so
+    # the captured stream may contain a command-echo line and any terraform
+    # warnings (lockfile, deprecations, etc.) before the JSON. Locate the JSON
+    # by content rather than trusting line counts.
+    show_json = extract_show_json(stdout)
 
     plan_json_file = plan_binary_file.parent / "tfplan.json"
     with plan_json_file.open("w") as plan_json_stream:
-        plan_json_stream.write(show_stdout)
+        plan_json_stream.write(show_json)
 
     return plan_json_file
 

--- a/terrawrap/utils/plan.py
+++ b/terrawrap/utils/plan.py
@@ -1,0 +1,25 @@
+"""Helpers for processing terraform plan output."""
+from typing import List
+
+
+def extract_show_json(stdout_lines: List[str]) -> str:
+    """
+    Extract the JSON output of `terraform show -json` from a captured stdout
+    stream that may contain non-JSON noise (the `tf` wrapper's command echo,
+    deprecation warnings, lockfile notices, etc.) interleaved before the JSON.
+
+    `terraform show -json` emits the plan as a single JSON object, so we locate
+    the first line whose first non-whitespace character is `{` and treat
+    everything from there onward as the JSON document.
+
+    :param stdout_lines: Lines captured from the command's stdout, each
+        retaining its trailing newline as returned by `readlines()`.
+    :return: The JSON content as a single string.
+    :raises RuntimeError: If no JSON line is found.
+    """
+    for i, line in enumerate(stdout_lines):
+        if line.lstrip().startswith("{"):
+            return "".join(stdout_lines[i:])
+    raise RuntimeError(
+        f"no JSON object found in `terraform show -json` output: {''.join(stdout_lines[-50:])}"
+    )

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.10.16"
+__version__ = "0.10.17"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_plan.py
+++ b/test/unit/test_plan.py
@@ -1,0 +1,47 @@
+"""Tests for plan output processing helpers"""
+from unittest import TestCase
+
+from terrawrap.utils.plan import extract_show_json
+
+
+class TestExtractShowJson(TestCase):
+    """Test extract_show_json"""
+
+    def test_strips_command_echo_prefix(self):
+        """Returns the JSON when only the tf-wrapper command echo precedes it"""
+        stdout = [
+            "Executing: terraform show -json /tmp/tfplan/foo/tfplan.binary\n",
+            '{"format_version":"1.2","resource_changes":[]}\n',
+        ]
+        self.assertEqual(
+            extract_show_json(stdout),
+            '{"format_version":"1.2","resource_changes":[]}\n',
+        )
+
+    def test_strips_stderr_noise_before_json(self):
+        """Strips stderr-merged noise (warnings) interleaved before the JSON
+
+        Regression: terraform stderr (lockfile/deprecation warnings) gets
+        merged into stdout by execute_command(capture_stderr=True); the old
+        stdout[1:] slice only stripped the command echo, leaving warning
+        lines as a non-JSON prefix that broke downstream `opa exec` parsing.
+        """
+        stdout = [
+            "Executing: terraform show -json /tmp/tfplan/foo/tfplan.binary\n",
+            "Warning: lock file mismatch\n",
+            "  on backend.tf line 5: deprecated argument\n",
+            '{"format_version":"1.2","resource_changes":[]}\n',
+        ]
+        self.assertEqual(
+            extract_show_json(stdout),
+            '{"format_version":"1.2","resource_changes":[]}\n',
+        )
+
+    def test_returns_json_when_no_preamble(self):
+        """Returns the JSON unchanged when stdout has no preamble lines"""
+        self.assertEqual(extract_show_json(['{"a":1}\n']), '{"a":1}\n')
+
+    def test_raises_when_no_json_present(self):
+        """Raises RuntimeError if there is no JSON line in stdout"""
+        with self.assertRaises(RuntimeError):
+            extract_show_json(["Executing: terraform show -json\n", "Error: no plan\n"])


### PR DESCRIPTION
## Summary

- Fix `convert_plan_to_json` in `bin/plan_check` so it produces valid `tfplan.json` even when terraform writes warnings to stderr (lockfile notices, deprecations, etc.). The prior `stdout[1:]` slice only stripped the `tf` wrapper's command-echo line; everything else got prepended to the JSON document and broke downstream parsing.
- Bump version to 0.10.17.

## Why this matters

`_execute_command` at `terrawrap/utils/cli.py:191` merges stderr into stdout (`capture_stderr=True`, the default). For most callers this is fine, but `convert_plan_to_json` writes that captured stream to `tfplan.json`, so any non-JSON stderr line ahead of the JSON object corrupts the file.

The bug was masked while `terraform-config`'s plan-check OPA gate was silently no-op'ing on an undefined decision path (amplify-education/terraform-config#33128). Once the gate was repaired in amplify-education/terraform-config#36214, `opa exec` started failing with `error: {}` — an empty Go error from a JSON parse failure whose underlying type has no exported fields — and surfaced on PRs like amplify-education/terraform-config#36229.

## Approach

`extract_show_json` (new in `terrawrap/utils/plan.py`) locates the first line whose first non-whitespace character is `{` and returns from there forward. Robust against any number of preceding non-JSON lines, no special-casing of the wrapper echo specifically. Raises `RuntimeError` with the trailing 50 lines of stdout if no JSON is found — matches the exception type the call site at `bin/plan_check:236` already catches, so the per-directory error path stays intact instead of crashing the whole `plan_check` run.

The existing failure-path message at `bin/plan_check:122` is also widened from `stdout[1:]` to the full captured stream so the command echo and any stderr context remain visible when `terraform show` itself fails (exit code FAILURE).

## Test plan

- [x] `pytest test/unit/test_plan.py` — 4 cases pass (command-echo prefix, stderr-noise prefix regression, no-preamble, no-JSON RuntimeError).
- [x] Full unit suite (`pytest test/unit`) — only the two pre-existing `test_config_mover` failures, unrelated to this PR.
- [x] `pre-commit run --files <changed>` — black, mypy, pylint all pass.
- [x] Two rounds of triaged code review (6 agents each). Round-1 caught one critical (`ValueError` vs `RuntimeError` mismatch with the call site's `except`); fixed in this commit. Round-2 found no MUST FIX items.
- [ ] After merge: re-run `terraform-config` PR amplify-education/terraform-config#36229 to confirm the OPA gate now passes (planned: pin terrawrap to 0.10.17 in the runner image and re-run plan-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)