### PR TITLE
Fix duplicate tfaudit records from GraphEntry apply path (AT-14812)

### DIFF
--- a/terrawrap/models/graph_entry.py
+++ b/terrawrap/models/graph_entry.py
@@ -107,7 +107,9 @@ class GraphEntry(Entry):
             env=command_env,
             shell=shell,
             cwd=self.path,
-            audit_api_url=self.wrapper_config.audit_api_url,
+            # audit_api_url intentionally omitted: the `tf` wrapper (bin/tf)
+            # already reports to the audit API when it runs terraform
+            # apply/destroy. Passing it here would double-report. See AT-14812.
         )
 
         if operation_exit_code == 0:

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.10.17"
+__version__ = "0.10.18"
 __git_hash__ = "GIT_HASH"

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.10.18"
+__version__ = "0.10.19"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_graph_entry.py
+++ b/test/unit/test_graph_entry.py
@@ -68,8 +68,11 @@ class TestGraphEntry(TestCase):
         self.assertEqual(changes_detected, False)
 
     @patch("terrawrap.models.graph_entry.execute_command")
-    def test_execute_passes_audit_api_url(self, exec_command):
-        """Test that audit_api_url is passed to execute_command calls"""
+    def test_audit_api_url_only_to_init(self, exec_command):
+        """audit_api_url goes to init but NOT to the operation call.
+        The tf wrapper (bin/tf) handles audit reporting for apply/destroy;
+        reporting at this level too would create duplicate tfaudit records
+        (AT-14812)."""
         exec_command.side_effect = [
             (0, ["Success"]),
             (0, ["Success"]),
@@ -80,12 +83,15 @@ class TestGraphEntry(TestCase):
 
         self.assertEqual(exec_command.call_count, 2)
 
-        for call_args in exec_command.call_args_list:
-            self.assertIn("audit_api_url", call_args[1])
+        init_call_kwargs = exec_command.call_args_list[0][1]
+        operation_call_kwargs = exec_command.call_args_list[1][1]
+
+        self.assertIn("audit_api_url", init_call_kwargs)
+        self.assertNotIn("audit_api_url", operation_call_kwargs)
 
     @patch("terrawrap.models.graph_entry.execute_command")
     def test_execute_audit_api_url_value(self, exec_command):
-        """Test that the correct audit_api_url value is passed"""
+        """audit_api_url is only passed to init, not to the operation call."""
         exec_command.side_effect = [
             (0, ["Success"]),
             (0, ["Success"]),
@@ -99,4 +105,4 @@ class TestGraphEntry(TestCase):
         operation_call_kwargs = exec_command.call_args_list[1][1]
 
         self.assertIn("audit_api_url", init_call_kwargs)
-        self.assertIn("audit_api_url", operation_call_kwargs)
+        self.assertNotIn("audit_api_url", operation_call_kwargs)


### PR DESCRIPTION
## Summary
- `GraphEntry.execute()` was passing `audit_api_url` to the operation `execute_command()` call, which made the outer shell-level invocation report to the audit API. The inner `tf` wrapper already reports — so every ECS-based `graph_apply` produced two `applies` rows per directory (~50% of tfaudit rows are duplicates).
- Drop `audit_api_url` from the operation call only. The `init` call still passes it (harmless — `cli.py`'s gate checks `"apply" in args`, which never matches `init`).
- Update the two unit tests in `test_graph_entry.py` to assert `audit_api_url` is absent from the operation call's kwargs.

## Test plan
- [x] `pytest test/unit/test_graph_entry.py` — all 6 tests pass
- [ ] After deploy, run `tfaudit search --directory <freq-applied-dir> --limit 10` and confirm each pipeline ID appears once (was twice)
- [ ] Spot-check that the remaining record has a populated `prev_successful_git_hash` (the `tf`-wrapper record is the better one)
- [ ] Confirm CodeBuild-based applies are unaffected (they call `tf` directly, not through `GraphEntry`)

## Notes
- No data loss: the `tf` wrapper's record has accurate `start_time`, `duration`, and `prev_successful_git_hash`.
- Downstream dashboards counting applies will drop ~50% for ECS-based pipelines — that reflects reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)