### PR TITLE
Suppress RC upgrade notice when a newer stable already exists

### DIFF
--- a/terrawrap/utils/version.py
+++ b/terrawrap/utils/version.py
@@ -35,7 +35,11 @@ def version_check(current_version: str) -> bool:
             )
             is_stale = True
 
-        if latest_rc and version.parse(latest_rc) > current:
+        if (
+            latest_rc
+            and version.parse(latest_rc) > current
+            and version.parse(latest_rc) > version.parse(latest_stable)
+        ):
             print(
                 f"NOTE: A release candidate {latest_rc} is available for testing. It may contain bugs.",
                 f"\nTo opt in, run: pip install terrawrap=={latest_rc}\n",

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.10.17"
+__version__ = "0.10.18"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_version.py
+++ b/test/unit/test_version.py
@@ -63,6 +63,39 @@ class TestVersion(TestCase):
 
         self.assertTrue(response)
 
+    @patch("terrawrap.utils.version.sleep", MagicMock())
+    @patch("terrawrap.utils.version.get_latest_version")
+    def test_version_check_rc_older_than_stable(self, mock_get_latest_version):
+        """RC alert is suppressed when an equal-or-newer stable already exists"""
+        current_version = "1.0.0"
+        # An RC for 1.1.0 exists, but 1.1.0 stable has already shipped — don't
+        # suggest opting into the older RC.
+        mock_get_latest_version.return_value = ("1.1.0", "1.1.0rc2")
+
+        with patch("sys.stderr") as mock_stderr:
+            response = version_check(current_version=current_version)
+
+        self.assertTrue(response)
+        printed = "".join(
+            call.args[0] for call in mock_stderr.write.call_args_list if call.args
+        )
+        self.assertNotIn("release candidate", printed)
+
+    @patch("terrawrap.utils.version.get_latest_version")
+    def test_version_check_rc_on_matching_stable(self, mock_get_latest_version):
+        """No RC alert when current version is the published release of that RC"""
+        current_version = "0.11.0"
+        mock_get_latest_version.return_value = ("0.11.0", "0.11.0rc2")
+
+        with patch("sys.stderr") as mock_stderr:
+            response = version_check(current_version=current_version)
+
+        self.assertFalse(response)
+        printed = "".join(
+            call.args[0] for call in mock_stderr.write.call_args_list if call.args
+        )
+        self.assertNotIn("release candidate", printed)
+
     @patch("terrawrap.utils.version.get_latest_version")
     def test_version_check_handles_exception(self, mock_get_latest_version):
         """VersionUtils version check swallows exception"""


### PR DESCRIPTION
## Summary
- The version check nudged users to opt into an RC (`0.11.0rc2`) even after its final release (`0.11.0`) had shipped — because the RC was still newer than the user's current version.
- Now we only show the RC notice when `latest_rc > latest_stable`, so a superseded RC stays quiet.

## Test plan
- [x] `pytest test/unit/test_version.py` — 10 tests pass, including two new cases:
  - RC older than latest stable is suppressed
  - On the matching stable, no RC alert
- [ ] Spot-check locally on a stale install once merged/released

🤖 Generated with [Claude Code](https://claude.com/claude-code)