### PR TITLE
Fix plan_check missing dep on default-overridden auto.tfvars

### DIFF
--- a/terrawrap/utils/tf_variables.py
+++ b/terrawrap/utils/tf_variables.py
@@ -59,8 +59,25 @@ def get_nondefault_variables_for_file(file_path: str) -> Set[str]:
         tf_info = hcl2.load(file)
         for variable in tf_info.get("variable", []):
             for variable_name, var_config in variable.items():
-                if not var_config.get("default"):
+                # Use existence check, not truthiness — `default = false`/`0`/`""`/`[]`
+                # is still a declared default.
+                if "default" not in var_config:
                     variables.add(variable_name)
+
+    return variables
+
+
+def get_declared_variables_for_file(file_path: str) -> Set[str]:
+    """
+    Find all variables declared in a terraform file, regardless of default value.
+    :param file_path: a terraform file
+    :return: Set of variable names declared in the file
+    """
+    variables = set()
+    with open(file_path, "r", encoding="utf-8") as file:
+        tf_info = hcl2.load(file)
+        for variable in tf_info.get("variable", []):
+            variables.update(variable.keys())
 
     return variables
 
@@ -137,8 +154,10 @@ def get_auto_var_usage_graph(root_directory: str) -> DiGraph:
 def _collect_variable_usages(
     current_dir: str, file: str, auto_vars: Dict[str, Set[Variable]]
 ) -> Tuple[str, Set[str]]:
+    # Every declared variable, not just non-default ones: an upstream auto.tfvars
+    # value overrides a downstream default, so the dependency must be tracked.
     var_sources = set()
-    for variable in get_nondefault_variables_for_file(os.path.join(current_dir, file)):
+    for variable in get_declared_variables_for_file(os.path.join(current_dir, file)):
         var_source = get_source_for_variable(current_dir, variable, auto_vars)
         if var_source:
             var_sources.add(var_source)

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.10.19"
+__version__ = "0.10.20"
 __git_hash__ = "GIT_HASH"

--- a/test/helpers/mock_directory/config/area/area.auto.tfvars
+++ b/test/helpers/mock_directory/config/area/area.auto.tfvars
@@ -1,0 +1,1 @@
+region_setting = "us-west-2"

--- a/test/helpers/mock_directory/config/area/svc/variables.tf
+++ b/test/helpers/mock_directory/config/area/svc/variables.tf
@@ -1,0 +1,7 @@
+variable "region_setting" {
+  default = "us-east-1"
+}
+
+variable "feature_enabled" {
+  default = false
+}

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -113,10 +113,11 @@ class TestConfig(TestCase):
 
         app1 = os.path.join(os.getcwd(), "mock_directory/config/app1")
         app2 = os.path.join(os.getcwd(), "mock_directory/config/app2")
+        area_svc = os.path.join(os.getcwd(), "mock_directory/config/area/svc")
 
         app_team_4 = os.path.join(os.getcwd(), "mock_directory/config/team/app4")
 
-        expected_post_graph = [app1, app2, app_team_4]
+        expected_post_graph = [app1, app2, area_svc, app_team_4]
 
         expected_post_graph.sort()
         actual_post_graph.sort()

--- a/test/unit/test_config_mover.py
+++ b/test/unit/test_config_mover.py
@@ -3,8 +3,10 @@
 import contextlib
 import io
 import shutil
+import tempfile
 import uuid
 from pathlib import Path
+from typing import Optional
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
@@ -23,10 +25,6 @@ class TestConfigMover(TestCase):
 
     _base_path = (Path(__file__) / "../../helpers").resolve() / "mock_config_mover"
     _mocks_path = _base_path / "mocks"
-    _repo_root_path = _base_path / "terraform-config"
-    _config_path = _repo_root_path / "config"
-    _default_source = _config_path / "aws" / "default_source"
-    _default_target = _config_path / "aws" / "default_target"
 
     @staticmethod
     def _read_hcl2_modules(hcl2_content: str):
@@ -37,23 +35,43 @@ class TestConfigMover(TestCase):
             result[list(module.keys())[0]] = list(module.values())[0]
         return result
 
-    @classmethod
     def config_mover(
-        cls,
-        source: Path = _default_source,
-        target: Path = _default_target,
+        self,
+        source: Optional[Path] = None,
+        target: Optional[Path] = None,
     ) -> ConfigMover:
-        return ConfigMover(source, target)
+        return ConfigMover(
+            self._default_source if source is None else source,
+            self._default_target if target is None else target,
+        )
 
     def setUp(self):
+        # Per-test unique working tree + isolated inner git repo. Without isolation,
+        # parallel tox envs (-p auto) race on `mock_config_mover/terraform-config/`
+        # AND on the outer terrawrap repo's `.git/index.lock` (because ConfigMover
+        # walks up to find a .git dir).
+        # `.resolve()` to dodge the macOS /var → /private/var symlink, which
+        # otherwise trips git's "path not in repo" check on the index.
+        self._tmpdir = Path(tempfile.mkdtemp(prefix="env_")).resolve()
+        self._repo_root_path = self._tmpdir / "terraform-config"
+        self._config_path = self._repo_root_path / "config"
+        self._default_source = self._config_path / "aws" / "default_source"
+        self._default_target = self._config_path / "aws" / "default_target"
         self._default_source.mkdir(parents=True, exist_ok=True)
         self._default_target.mkdir(parents=True, exist_ok=True)
+        # Init isolated repo so ConfigMover finds it instead of climbing to terrawrap.
+        # Add a fake origin so `calc_repo_path` (which shells out to
+        # `git remote show origin`) can parse a repo name.
+        inner_repo = git.Repo.init(self._repo_root_path)
+        inner_repo.create_remote(
+            "origin", "https://github.com/amplify-education/terraform-config.git"
+        )
         self.prev_dir = Path(os.getcwd()).absolute()
         os.chdir(self._repo_root_path)
 
     def tearDown(self):
-        shutil.rmtree(self._repo_root_path, ignore_errors=True)
         os.chdir(self.prev_dir)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
 
     @patch("terrawrap.models.config_mover.find_variable_files")
     def test__find_variable_files(self, find_variable_files_mock: MagicMock):

--- a/test/unit/test_path.py
+++ b/test/unit/test_path.py
@@ -40,6 +40,10 @@ class TestPath(TestCase):
                 "config/app4/.tf_wrapper",
                 "config/app5",
                 "config/app5/app.auto.tfvars",
+                "config/area",
+                "config/area/area.auto.tfvars",
+                "config/area/svc",
+                "config/area/svc/variables.tf",
                 "config/global.auto.tfvars",
                 "config/team",
                 "config/team/app4",
@@ -61,6 +65,8 @@ class TestPath(TestCase):
                 ("config/app1/test.tf", "config/app1"),
                 ("config/app1/app.auto.tfvars", "config/app1"),
                 ("config/app1/variables.tf", "config/app1"),
+                ("config/area/area.auto.tfvars", "config/area"),
+                ("config/area/svc/variables.tf", "config/area/svc"),
             ]
         )
         self.assertEqual(set(actual.nodes), set(expected.nodes))

--- a/test/unit/test_tf_variables.py
+++ b/test/unit/test_tf_variables.py
@@ -50,6 +50,9 @@ class TestTerraformVariables(TestCase):
                 "config/app5/app.auto.tfvars": {
                     Variable("foo", ((("key", "value"),),)),
                 },
+                "config/area/area.auto.tfvars": {
+                    Variable("region_setting", "us-west-2"),
+                },
             },
         )
 
@@ -58,6 +61,12 @@ class TestTerraformVariables(TestCase):
         actual = get_nondefault_variables_for_file("config/app1/variables.tf")
 
         self.assertEqual(actual, {"foo", "bar"})
+
+    def test_nondefault_excludes_falsy_default(self):
+        """A declared `default = false` (or 0, "", []) is still a default and must be excluded."""
+        actual = get_nondefault_variables_for_file("config/area/svc/variables.tf")
+
+        self.assertEqual(actual, set())
 
     def test_get_source_for_variable(self):
         """test getting the source of a auto var"""
@@ -81,14 +90,25 @@ class TestTerraformVariables(TestCase):
         expected.add_node("config/app3/app.auto.tfvars")
         expected.add_node("config/team/team.auto.tfvars")
         expected.add_node("config/app1/app.auto.tfvars")
+        expected.add_node("config/area/area.auto.tfvars")
         expected.add_node("config/app1")
         expected.add_node("config/app3")
         expected.add_node("config/team/app4")
+        expected.add_node("config/area/svc")
 
         expected.add_edge("config/global.auto.tfvars", "config/app1")
         expected.add_edge("config/global.auto.tfvars", "config/app3")
         expected.add_edge("config/app3/app.auto.tfvars", "config/app3")
         expected.add_edge("config/team/team.auto.tfvars", "config/team/app4")
         expected.add_edge("config/app1/app.auto.tfvars", "config/app1")
+        expected.add_edge("config/area/area.auto.tfvars", "config/area/svc")
 
         self.assertTrue(is_isomorphic(actual, expected))
+
+    def test_auto_var_usages_tracks_override(self):
+        """Upstream auto.tfvars overrides a downstream variable's default, so the edge must be present."""
+        actual = get_auto_var_usage_graph("config")
+
+        self.assertTrue(
+            actual.has_edge("config/area/area.auto.tfvars", "config/area/svc")
+        )


### PR DESCRIPTION
## Summary

- **Bug:** `plan_check --modified-only` skipped downstream config dirs whose only changed dependency was an upstream `*.auto.tfvars` value overriding a variable's truthy default. The auto-vars graph builder filtered out any declared default, so the edge from tfvars → consumer was never added.
- **Fix:** Iterate every declared variable in `_collect_variable_usages` via a new `get_declared_variables_for_file` helper; let `get_source_for_variable`'s existing "is there an upstream tfvars?" check decide edge inclusion.
- **Secondary:** `get_nondefault_variables_for_file` used `not var_config.get("default")` — a truthiness check that misclassified `default = false`/`0`/`""`/`[]` as "no default". Switched to existence check `"default" not in var_config`.

## Why this matters

Terraform precedence: env vars < `terraform.tfvars` < `*.auto.tfvars` < `-var`. Defaults only apply when nothing else provides a value, so an upstream tfvars override IS the effective value at plan time. The dependency graph has to track that or `--modified-only` PR runs silently miss directories that *would* see a real change.

## Tests (TDD)

Two new tests in `test/unit/test_tf_variables.py`, written before the fix and confirmed failing for the expected reasons first:

- `test_nondefault_excludes_falsy_default` — pins the existence-check fix.
- `test_auto_var_usages_tracks_override` — pins the graph-edge fix.

New fixtures under `test/helpers/mock_directory/config/area/` exercise both: `region_setting` (truthy default + upstream override) and `feature_enabled = false` (falsy default).

`test_get_auto_vars`, `test_get_auto_var_usages` (test_tf_variables.py), `test_walk_without_graph_directory` (test_config.py), and `test_get_file_graph` (test_path.py) updated for the new fixture nodes/edges.

## Drive-by: `test_config_mover` parallel-safety

Second commit (`test/unit/test_config_mover.py`) — unrelated to the bug, but `tox -p auto` (5 envs in parallel, used by the pre-commit `tox-on-stop` hook) was failing on this file because:

1. All envs shared `mock_config_mover/terraform-config/` → filesystem races (`git mv` "bad source", iterating UUID dirs another env removed).
2. `ConfigMover.repo` resolved via `search_parent_directories=True` → all envs hit the outer terrawrap `.git/index.lock` simultaneously, and `config_mover.repo.index.add(...)` was leaking staged-then-deleted entries into the developer's working tree.

`setUp` now allocates `tempfile.mkdtemp().resolve()` (the `.resolve()` dodges macOS's `/var` → `/private/var` symlink), `git init`s an isolated inner repo there with a fake origin (so `calc_repo_path` parses), and `tearDown` `rmtree`s the whole thing.

## Test plan

- [x] `tox -e py311-unit` — 78/78 pass locally
- [x] `tox -p auto --parallel-no-spinner` (matches CI's pre-commit hook) — 78×5 pass in parallel
- [x] pre-commit (black, mypy, pylint) clean
- [x] new tests fail before the fix, pass after (TDD verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)