### PR TITLE
fix(audit): derive SigV4 aws_host from audit_api_url

### DIFF
--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -8,6 +8,7 @@ import subprocess
 import tempfile
 import time
 from enum import Enum
+from urllib.parse import urlparse
 
 from typing import List, Optional, Tuple, Union
 
@@ -246,7 +247,7 @@ def _post_audit_info(
     )
 
     auth = BotoAWSRequestsAuth(
-        aws_host="terraform-audit-api.devops.amplify.com",
+        aws_host=urlparse(audit_api_url).hostname,
         aws_region="us-west-2",
         aws_service="execute-api",
     )

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.10.20"
+__version__ = "0.10.21"
 __git_hash__ = "GIT_HASH"

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.10.21"
+__version__ = "0.10.22"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -124,3 +124,22 @@ class TestCli(TestCase):
                 },
                 timeout=30,
             )
+
+    @patch("terrawrap.utils.cli.BotoAWSRequestsAuth")
+    @patch("requests.post")
+    def test_post_audit_info_signs_for_url_host(self, _, mock_auth):
+        """SigV4 host must come from the audit_api_url, not a hardcoded value."""
+        os.chdir(os.path.normpath(os.path.dirname(__file__) + "/../helpers"))
+
+        _post_audit_info(
+            audit_api_url="https://terraform-audit-api.devops-testing.amplify.com",
+            path=os.path.join(os.getcwd(), "mock_directory/config/.tf_wrapper"),
+            start_time=12345,
+            exit_code=0,
+        )
+
+        mock_auth.assert_called_with(
+            aws_host="terraform-audit-api.devops-testing.amplify.com",
+            aws_region="us-west-2",
+            aws_service="execute-api",
+        )

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -101,7 +101,7 @@ class TestCli(TestCase):
         """Test Audit API helper function for each possible status"""
         statuses = {Status.IN_PROGRESS: None, Status.FAILED: 2, Status.SUCCESS: 0}
 
-        fake_url = "foo.bar"
+        fake_url = "https://foo.bar"
         os.chdir(os.path.normpath(os.path.dirname(__file__) + "/../helpers"))
 
         for status, exit_code in statuses.items():
@@ -113,7 +113,7 @@ class TestCli(TestCase):
             )
 
             mock_post.assert_called_with(
-                url="foo.bar/audit_info",
+                url="https://foo.bar/audit_info",
                 auth=ANY,
                 json={
                     "directory": "/test/helpers/mock_directory/config/.tf_wrapper",


### PR DESCRIPTION
## Summary
- Derive the SigV4 `aws_host` in `_post_audit_info` from `audit_api_url` instead of the hardcoded prod hostname.
- Add a test asserting the host passed to `BotoAWSRequestsAuth` matches the URL's hostname.

Without this, any `audit_api_url` override (e.g., for a per-environment audit API) signs requests for the prod host and fails auth at the destination API.

Part of a 4-PR sequence to stand up a separate audit API in `amplify-devops-testing`. This PR must be released and rolled out to the terraform-config runtime image before the matching `.tf_wrapper` override in terraform-config is merged.

## Test plan
- [ ] `tox -e py39` passes.
- [ ] After release, smoke-test by running terrawrap against a config dir that uses the default audit URL and confirm the prod audit API still works.
- [ ] Verify in debug logs that `aws_host` resolves to the URL's hostname.