### PR TITLE
plan_check: TODO on hcl2/lark crash for precondition for-expressions

### DIFF
--- a/terrawrap/utils/module.py
+++ b/terrawrap/utils/module.py
@@ -53,6 +53,17 @@ def _get_modules_for_file(directory: str, file_name: str) -> Tuple[str, Set[str]
     modules = set()
     with open(directory + "/" + file_name, "r", encoding="utf-8") as file:
         try:
+            # TODO(plan_check parser): hcl2.load (python-hcl2 / lark) crashes
+            # with `KeyError: '__ANON_8'` on `alltrue([for x in y : ...])`
+            # expressions inside a resource `lifecycle.precondition` block.
+            # Reproduced on terraform-config PR #37051 when the dynamodb_table
+            # module added such a precondition: every plan_check job failed
+            # at graph-build time before any plan ran, because the walk hits
+            # the offending .tf file even when planning unrelated dirs.
+            # Fix paths: bump python-hcl2 once upstream lark grammar handles
+            # this, or wrap this load in a non-fatal log+skip so one parse
+            # bug doesn't disable the whole graph walk. See also the
+            # python-hcl2-v8 branch which may already address it.
             tf_info = hcl2.load(file)
             for module in tf_info.get("module", []):
                 for module_config in module.values():


### PR DESCRIPTION
## Summary

Add a `TODO` block-comment above the `hcl2.load(file)` call in `terrawrap/utils/module.py::_get_modules_for_file` documenting a python-hcl2 / lark parse crash hit by a downstream consumer.

## Repro

In terraform-config PR #37051, the `modules/aws/dynamodb_table/v1/table.tf` module added a `lifecycle.precondition` block that used:

```hcl
condition = alltrue([
  for idx in var.global_secondary_indexes :
  lookup(idx, "read_capacity", null) == null
  && lookup(idx, "write_capacity", null) == null
])
```

Every `plan_check` job in that PR crashed during the module-usage graph build with:

```
Error while parsing file .../modules/aws/dynamodb_table/v1/table.tf
KeyError: '__ANON_8'  (raised inside lark's LALR parser)
```

Zero terraform plans ran on any account because `_get_modules_for_file` raises and the graph walk dies on the first offending file — even on narrowly-scoped `plan_check` runs targeting unrelated directories, since the walk parses the whole repo.

## Fix paths (out of scope for this PR)

1. **Bump `python-hcl2`.** The repo's `python-hcl2-v8` branch may already address this; worth checking the grammar there before chasing a separate fix.
2. **Non-fatal parse**: log + skip a single file rather than `raise` so one malformed `.tf` (or one parser-tripping construct) can't block the entire graph walk. The current behavior conflates "I can't parse this file" with "this run is uncomputable," which is unsafe given how many module producers there are.

## Why a TODO and not a fix

This commit is purely documentation — leaves a breadcrumb at the parse site for the next reader. The fix (parser bump or skip-on-error) deserves its own PR with test coverage.

## Test plan

- [ ] Pre-commit (`black`, `mypy`, `pylint`) — passed locally
- [ ] No runtime behavior change to verify