### PR TITLE
fix(audit): surface exception, response, and caller-ARN on audit POST failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## \[0.10.23\] - 2026-05-29
+
+### Fixed
+
+- Surface the underlying exception, HTTP status, `x-amzn-errortype`, response
+  body, and boto3 default-chain caller ARN when `_post_audit_info` fails to
+  POST to the terraform audit API. Previously these failures logged only the
+  target URL, leaving engineers without enough signal to distinguish a 403
+  from a missing-credential or network error.
+
+## \[0.10.22\] - 2026-05-28
+
+### Fixed
+
+- Derive the SigV4 `aws_host` from `audit_api_url` (via `urlparse`) instead of
+  using a hardcoded host. This makes the audit POST sign correctly for the
+  per-environment audit-API endpoint in `devops-testing`, where the host
+  differs from `devops`.
+
 ## \[0.10.21\] - 2026-05-21
 
 ### Added

--- a/terrawrap/utils/aws.py
+++ b/terrawrap/utils/aws.py
@@ -1,0 +1,31 @@
+"""Shared AWS utility helpers."""
+import logging
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import BotoCoreError, ClientError
+
+logger = logging.getLogger(__name__)
+
+_STS_CONFIG = Config(
+    connect_timeout=3,
+    read_timeout=3,
+    retries={"max_attempts": 0},
+)
+
+_UNKNOWN_SENTINEL = "<unknown — sts:GetCallerIdentity failed>"
+
+
+def get_caller_arn(sts_client=None) -> str:
+    """Return the caller's ARN via STS, or a sentinel string on failure.
+
+    :param sts_client: Optional pre-constructed STS client (for testing).
+    :return: The caller ARN string, or ``_UNKNOWN_SENTINEL`` on any STS error.
+    """
+    if sts_client is None:
+        sts_client = boto3.client("sts", config=_STS_CONFIG)
+    try:
+        return sts_client.get_caller_identity()["Arn"]
+    except (ClientError, BotoCoreError) as exc:
+        logger.warning("Failed to resolve caller identity: %s", exc)
+        return _UNKNOWN_SENTINEL

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -13,11 +13,11 @@ from urllib.parse import urlparse
 from typing import List, Optional, Tuple, Union
 
 import requests
-
 from amplify_aws_utils.resource_helper import Jitter
 from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
 from requests.exceptions import HTTPError
 
+from terrawrap.utils.aws import get_caller_arn
 from terrawrap.utils.git_utils import get_git_root, get_git_hash
 
 logger = logging.getLogger(__name__)
@@ -283,5 +283,29 @@ def _post_audit_info(
         )
         response.raise_for_status()
         logger.info("Successfully posted data to provided url: %s", audit_api_url)
-    except requests.exceptions.RequestException:
+    except requests.exceptions.RequestException as exc:
         logger.error("Unable to post data to provided url: %s", audit_api_url)
+        logger.error(
+            "Audit API request failed: %s: %s",
+            type(exc).__name__,
+            exc,
+        )
+        response_obj = getattr(exc, "response", None)
+        if response_obj is not None:
+            try:
+                body_text = (response_obj.text or "")[:500]
+                logger.error(
+                    "Audit API response status=%s x-amzn-errortype=%s body=%s",
+                    response_obj.status_code,
+                    response_obj.headers.get("x-amzn-errortype", "<absent>"),
+                    body_text,
+                )
+            except Exception as decode_exc:  # pylint: disable=broad-except
+                logger.error(
+                    "Audit API response status=%s x-amzn-errortype=%s body=<decode failed: %s>",
+                    response_obj.status_code,
+                    response_obj.headers.get("x-amzn-errortype", "<absent>"),
+                    decode_exc,
+                )
+        caller_arn = get_caller_arn()
+        logger.error("Audit API signing identity (boto3 default chain): %s", caller_arn)

--- a/terrawrap/utils/ssm_resolver.py
+++ b/terrawrap/utils/ssm_resolver.py
@@ -12,7 +12,9 @@ from typing import Dict, List, Optional
 
 import boto3
 from amplify_aws_utils.resource_helper import throttled_call
-from botocore.exceptions import BotoCoreError, ClientError
+from botocore.exceptions import ClientError
+
+from terrawrap.utils.aws import get_caller_arn
 
 logger = logging.getLogger(__name__)
 
@@ -52,12 +54,7 @@ class SsmResolver:
 
     def _caller(self) -> str:
         if self._caller_arn is None:
-            client = self._sts_client or boto3.client("sts")
-            try:
-                self._caller_arn = client.get_caller_identity()["Arn"]
-            except (ClientError, BotoCoreError) as exc:
-                logger.warning("Failed to resolve caller identity: %s", exc)
-                self._caller_arn = "<unknown — sts:GetCallerIdentity failed>"
+            self._caller_arn = get_caller_arn(sts_client=self._sts_client)
         return self._caller_arn
 
     def resolve(self, paths: List[str]) -> str:

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.10.22"
+__version__ = "0.10.23"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_aws.py
+++ b/test/unit/test_aws.py
@@ -1,0 +1,64 @@
+"""Tests for terrawrap.utils.aws shared helpers."""
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from botocore.exceptions import ClientError, NoCredentialsError
+
+from terrawrap.utils.aws import get_caller_arn, _UNKNOWN_SENTINEL
+
+
+def _client_error(code: str) -> ClientError:
+    return ClientError(
+        error_response={"Error": {"Code": code, "Message": "stubbed"}},
+        operation_name="GetCallerIdentity",
+    )
+
+
+class TestGetCallerArn(TestCase):
+    """Unit tests for get_caller_arn."""
+
+    def test_happy_path_returns_arn(self):
+        """Returns the ARN string when STS succeeds."""
+        sts = MagicMock()
+        sts.get_caller_identity.return_value = {
+            "Arn": "arn:aws:sts::123456789012:assumed-role/Role/session"
+        }
+
+        result = get_caller_arn(sts_client=sts)
+
+        self.assertEqual("arn:aws:sts::123456789012:assumed-role/Role/session", result)
+        sts.get_caller_identity.assert_called_once()
+
+    def test_client_error_returns_sentinel(self):
+        """Returns the sentinel string on a ClientError from STS."""
+        sts = MagicMock()
+        sts.get_caller_identity.side_effect = _client_error("InvalidClientTokenId")
+
+        result = get_caller_arn(sts_client=sts)
+
+        self.assertEqual(_UNKNOWN_SENTINEL, result)
+
+    def test_no_credentials_returns_sentinel(self):
+        """Returns the sentinel string when no AWS credentials are configured."""
+        sts = MagicMock()
+        sts.get_caller_identity.side_effect = NoCredentialsError()
+
+        result = get_caller_arn(sts_client=sts)
+
+        self.assertEqual(_UNKNOWN_SENTINEL, result)
+
+    def test_sentinel_substrings(self):
+        """Sentinel string contains '<unknown' and 'sts:GetCallerIdentity failed'."""
+        self.assertIn("<unknown", _UNKNOWN_SENTINEL)
+        self.assertIn("sts:GetCallerIdentity failed", _UNKNOWN_SENTINEL)
+
+    def test_warning_logged_on_failure(self):
+        """A warning is emitted when the STS call fails."""
+        sts = MagicMock()
+        sts.get_caller_identity.side_effect = NoCredentialsError()
+
+        with self.assertLogs("terrawrap.utils.aws", level="WARNING") as ctx:
+            get_caller_arn(sts_client=sts)
+
+        messages = "\n".join(ctx.output)
+        self.assertIn("Failed to resolve caller identity", messages)

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -2,7 +2,10 @@
 import os
 from logging import Logger
 from unittest import TestCase
-from unittest.mock import patch, ANY, call
+from unittest.mock import patch, ANY, call, Mock
+
+import requests
+from botocore.exceptions import NoCredentialsError
 from requests.exceptions import HTTPError
 
 from terrawrap.utils.cli import execute_command, MAX_RETRIES, Status, _post_audit_info
@@ -143,3 +146,72 @@ class TestCli(TestCase):
             aws_region="us-west-2",
             aws_service="execute-api",
         )
+
+    @patch("terrawrap.utils.aws.boto3.client")
+    @patch("terrawrap.utils.cli.BotoAWSRequestsAuth")
+    @patch("requests.post")
+    def test_audit_info_logs_http_error_details(self, mock_post, _, mock_boto_client):
+        """On HTTPError with a response, log status, x-amzn-errortype, and caller ARN."""
+        os.chdir(os.path.normpath(os.path.dirname(__file__) + "/../helpers"))
+
+        response = Mock(spec=requests.Response)
+        response.status_code = 403
+        response.text = '{"message":"User is not authorized"}'
+        response.headers = {"x-amzn-errortype": "AccessDeniedException"}
+        http_error = requests.exceptions.HTTPError(response=response)
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = http_error
+        mock_post.return_value = mock_response
+
+        mock_sts = Mock()
+        mock_sts.get_caller_identity.return_value = {
+            "Arn": "arn:aws:sts::123456789012:assumed-role/test-role/brandon"
+        }
+        mock_boto_client.return_value = mock_sts
+
+        with self.assertLogs("terrawrap.utils.cli", level="ERROR") as ctx:
+            _post_audit_info(
+                audit_api_url="https://terraform-audit-api.devops.amplify.com",
+                path=os.path.join(os.getcwd(), "mock_directory/config/.tf_wrapper"),
+                start_time=12345,
+                exit_code=1,
+            )
+
+        messages = "\n".join(ctx.output)
+        self.assertIn("Unable to post data to provided url", messages)
+        self.assertIn("403", messages)
+        self.assertIn("AccessDeniedException", messages)
+        self.assertIn("User is not authorized", messages)
+        self.assertIn(
+            "arn:aws:sts::123456789012:assumed-role/test-role/brandon", messages
+        )
+
+    @patch("terrawrap.utils.aws.boto3.client")
+    @patch("terrawrap.utils.cli.BotoAWSRequestsAuth")
+    @patch("requests.post")
+    def test_audit_info_sts_failure_unmasked(self, mock_post, _, mock_boto_client):
+        """An STS failure must not mask the original RequestException."""
+        os.chdir(os.path.normpath(os.path.dirname(__file__) + "/../helpers"))
+
+        mock_post.side_effect = requests.exceptions.ConnectionError(
+            "connection refused"
+        )
+
+        mock_sts = Mock()
+        mock_sts.get_caller_identity.side_effect = NoCredentialsError()
+        mock_boto_client.return_value = mock_sts
+
+        with self.assertLogs("terrawrap.utils.cli", level="ERROR") as ctx:
+            _post_audit_info(
+                audit_api_url="https://terraform-audit-api.devops.amplify.com",
+                path=os.path.join(os.getcwd(), "mock_directory/config/.tf_wrapper"),
+                start_time=12345,
+                exit_code=1,
+            )
+
+        messages = "\n".join(ctx.output)
+        self.assertIn("Unable to post data to provided url", messages)
+        self.assertIn("ConnectionError", messages)
+        self.assertIn("connection refused", messages)
+        self.assertIn("<unknown", messages)
+        self.assertIn("sts:GetCallerIdentity failed", messages)


### PR DESCRIPTION
## Summary
- Audit-API failures in `_post_audit_info` previously logged only the target URL — making 403-from-ARN-not-on-allowlist indistinguishable from missing boto3 credentials or a connect timeout. Now logs exception type, HTTP status + `x-amzn-errortype` + truncated body, and the boto3 default-chain caller ARN. STS lookup is wrapped so its own failure cannot mask the primary RequestException.
- Extracts the caller-ARN lookup (also previously inlined in `SsmResolver._caller`) into a shared `terrawrap.utils.aws.get_caller_arn` helper with a bounded STS `Config(connect_timeout=3, read_timeout=3, retries=0)`. Both call sites now delegate to the helper.
- Behavior unchanged: `_post_audit_info` still swallows `RequestException` so audit failures cannot break terraform apply, and the existing `"Unable to post data to provided url"` log line is preserved verbatim for runbook compatibility.

## Test plan
- [x] `tox -e py313-unit` — 145/145 pass (3 new tests on `get_caller_arn`, 2 new tests on `_post_audit_info` error paths)
- [x] `pre-commit run --files ...` clean (black, mypy, pylint)
- [ ] Trigger a known failure mode locally (`unset AWS_PROFILE && tf apply` on a no-op change) and confirm the new diagnostic lines appear in stderr