### PR TITLE
fix(cli): retry on 504 Gateway Timeout

### DIFF
--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -41,6 +41,7 @@ RETRIABLE_ERRORS = [
     "Api Rate Limit Exceeded",
     "TooManyUpdates",
     "409 Conflict",
+    "504 Gateway Timeout",
 ]
 AUDIT_POST_PATH = "/audit_info"
 AUDIT_UPDATE_PATH = "/update_audit_info"

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.10.22"
+__version__ = "0.10.23"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -5,7 +5,13 @@ from unittest import TestCase
 from unittest.mock import patch, ANY, call
 from requests.exceptions import HTTPError
 
-from terrawrap.utils.cli import execute_command, MAX_RETRIES, Status, _post_audit_info
+from terrawrap.utils.cli import (
+    execute_command,
+    MAX_RETRIES,
+    Status,
+    _post_audit_info,
+    _get_retriable_errors,
+)
 
 
 MOCK_ERROR = HTTPError()
@@ -72,6 +78,19 @@ class TestCli(TestCase):
         self.assertEqual(self.mock_popen.call_count, MAX_RETRIES)
         self.assertEqual(exit_code, 255)
         self.assertEqual(stdout, [])
+
+    def test_get_retriable_errors_504(self):
+        """Lines carrying a known transient signature (e.g. a 504 Gateway
+        Timeout from the backend API) are retriable; unrelated lines are not."""
+        lines = [
+            "Error: error updating monitor: 504 Gateway Timeout\n",
+            "Error: invalid resource address\n",
+        ]
+
+        self.assertEqual(
+            _get_retriable_errors(lines),
+            ["Error: error updating monitor: 504 Gateway Timeout\n"],
+        )
 
     @patch.object(Logger, "error")
     @patch("terrawrap.utils.cli._post_audit_info")


### PR DESCRIPTION
## What

Add `"504 Gateway Timeout"` to `RETRIABLE_ERRORS` in `terrawrap/utils/cli.py`.

## Why

A Datadog `apply` failed hard on a transient `504 Gateway Timeout` from the
backend API. The retry path already exists — `execute_command(retry=True)`
retries up to `MAX_RETRIES` with jitter backoff whenever a stdout line matches
any `RETRIABLE_ERRORS` substring — but `504 Gateway Timeout` was not in the
list, so the run aborted instead of retrying.

Note: the original report pointed at `bin/tf`, but that loop only handles
errors needing **remediation** (state-lock unlock, digest fix, state repush).
Transient HTTP/network retries are owned by `cli.py`, which is where this fix
belongs.

## Scope of the match

Exact substring match. `504 Gateway Timeout` is the standard HTTP reason
phrase. It intentionally does **not** match a bare `504` (would spuriously
retry on IDs/counts/byte sizes) nor the nginx variant `504 Gateway Time-out`
(hyphen). If we later see the hyphenated form in the wild, add it separately.

## Tests

Added `test_get_retriable_errors_504` exercising the real `_get_retriable_errors`
(the existing retry tests mock it out, so the string list itself was untested).

- `tox -e py310-unit`: 139 passed
- `tox -e py312-unit`: 139 passed
- pylint: 10.00/10

Version bumped `0.10.22` → `0.10.23` for the version-bump pre-commit gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)