### PR TITLE
fix: emit version-check exception warning to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## \[0.10.25\] - 2026-06-17
+
+### Fixed
+
+- `version_check` exception handler now emits its warning to `stderr` instead of
+  `stdout`. When the PyPI version lookup fails (network timeout, unreachable host),
+  the bare `print()` was writing to stdout and could corrupt the output of
+  subsequent `terraform show -json` calls, producing `no JSON object found` parse
+  failures in the plan-check pipeline. (PR #230)
+
 ## \[0.10.24\] - 2026-06-09
 
 ### Fixed

--- a/terrawrap/utils/version.py
+++ b/terrawrap/utils/version.py
@@ -54,6 +54,7 @@ def version_check(current_version: str) -> bool:
     except Exception as exp:
         print(
             f"WARNING: Encountered some error while checking for latest version of Terrawrap: {repr(exp)}",
+            file=sys.stderr,
         )
     return False
 

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.10.24"
+__version__ = "0.10.25"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
## Summary
- The \`except\` block in \`version_check()\` used a bare \`print()\` that wrote to stdout
- When the PyPI version lookup fails in CI (network timeout, unreachable), the warning message corrupts subsequent \`terraform show -json\` output, causing \`no JSON object found\` parse failures in the plan-check pipeline
- The stale-version warning path (lines 29–35) already used \`file=sys.stderr\` correctly; only the exception path was missing it
- Bumps to 0.10.25 (patch)

## Test plan
- [ ] \`tox\` passes
- [ ] Confirm \`version_check()\` exception path writes to stderr (not stdout)
🤖 Generated with [Claude Code](https://claude.com/claude-code)