### PR TITLE
docs: note local pyenv drift and worktree pythonpath gotcha in claude.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,15 @@ the heading version to the value you just wrote into `version.py`.
   declaring done.
 - pre-commit runs black (pinned `22.8.0`), mypy, and pylint (scoped to
   `terrawrap/` and `test/` — `bin/` scripts are not linted).
+
+## Local Dev Env
+
+A local pyenv env for this repo can drift behind `origin/main`'s
+`requirements.txt` (a new pinned dependency isn't installed until you
+re-`pip install`) — a pytest collection `ImportError` on an unrelated-looking
+module is often this, not a real regression.
+
+In a worktree checked out off a newer `origin/main` than the editable
+install's target, run pytest with `PYTHONPATH=$(pwd)` so the worktree's copy
+of `terrawrap` shadows the stale editable install pointing at the main
+checkout.


### PR DESCRIPTION
## Summary
- Add a **Local Dev Env** note to `CLAUDE.md`: a stale local pyenv env can produce a misleading pytest collection `ImportError` when `origin/main` has added a pinned dependency; run with `PYTHONPATH=$(pwd)` in a worktree ahead of the editable install's target.

Most of the source memory's content (py310 floor, full-tox requirement, pinned black 22.8.0) was already documented in this file, in more detail than the memory had. This PR adds only the genuinely missing piece.

## Test plan
- [x] `pre-commit run --files CLAUDE.md` — passes
- [x] Read the existing `CLAUDE.md` first to confirm no duplication before adding