### PR TITLE
Clean up vestigial mypy/type-stub deps now covered by additional_dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,4 @@ repos:
           - types-PyYAML==6.0.12.9
           - types-python-dateutil==2.8.19.12
           - types-pytz==2023.3.0.0
+          - types-filelock>=3.0.12,<4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## \[0.10.28\] - 2026-07-18
+
+### Changed
+
+- Removed the vestigial `mypy` pin and moved `types-*` packages from `test-requirements.txt`
+  into the `mirrors-mypy` hook's `additional_dependencies`, where the pinned mypy the hook
+  actually runs can see them.
+
 ## \[0.10.26\] - 2026-07-16
 
 ### Changed

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.10.27"
+__version__ = "0.10.28"
 __git_hash__ = "GIT_HASH"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,11 +1,5 @@
 -r requirements.txt
 
-# Linting tools
-mypy>=1.10.0,<2
-# mypy types
-types-PyYAML>=5.4.3,<6
-types-filelock>=3.0.12,<4
-types-requests>=2.31.0,<3
 # Testing tools
 pytest>=7.4.0,<8
 pytest-cov>=4.1.0,<5


### PR DESCRIPTION
Mechanical cleanup: these repos already run mypy via the `pre-commit/mirrors-mypy`
hook, but still carried a vestigial `mypy` pin (and in some cases boto3 type-stub
packages) in requirements/test-requirements files left over from before that hook
existed. Per [eng-guidance:pre-commit](https://eng-guidance-mcp-devops.devops.amplify.com/guidance/pre-commit),
type stubs belong in the hook's `additional_dependencies`, not requirements files.

Changes:
- Remove the dead `mypy` pin (the hook installs its own pinned mypy into an isolated venv)
- Move `types-*`/`mypy-boto3-*`/`boto3-stubs` packages into `additional_dependencies`, deduped against what was already declared there
- `python-hcl2` only: bump the mirrors-mypy rev off a pre-v1.0 pin and drop the accompanying `language_version` workaround (the typed-ast/Python-3.12-wheel issue that pin exists for)
- `codebuild_slack_notifier` only: drop a redundant `mypy .` invocation from tox's lint testenv, now superseded by the hook

Generated with assistance from Claude Code; see the commit trailer for co-authorship.