### PR TITLE
fix: surface real cause of plan_check's show-json failures, retry the flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- `convert_plan_to_json` retries `terraform show -json` once when the first attempt exits
-  without the FAILURE code but still produces no JSON. Observed intermittently in
-  amplify-education/terraform-config CI under `--parallel-jobs=16`, hitting a different
-  directory on different runs each time (never the same directory twice) — a same-input
-  retry reliably clears it. `extract_show_json`'s error message now also names the exit
-  code and explicitly flags a genuinely empty capture, instead of surfacing only whatever
-  noise (e.g. the version-staleness banner below) happened to precede the missing JSON.
+- `convert_plan_to_json` retries `terraform show -json` once when the first attempt exits 0
+  but still produces no JSON. Observed intermittently in amplify-education/terraform-config
+  CI under `--parallel-jobs=16`, hitting a different directory on different runs each time
+  (never the same directory twice) — a same-input retry reliably clears it. Any non-zero
+  exit is still a hard failure and is never retried. `extract_show_json`'s error message
+  now also names the exit code and explicitly flags a genuinely empty capture, instead of
+  surfacing only whatever noise (e.g. the version-staleness banner below) happened to
+  precede the missing JSON.
 - `plan_check`'s nested `tf` subprocess calls (init, plan, and the show-to-JSON conversion)
   now pass the new `tf --no-version-check` flag. Each of these calls previously re-ran its
   own PyPI staleness check and printed a "Terrawrap is stale" banner to stderr, which
@@ -27,6 +28,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `tf --no-version-check`: skips the per-invocation PyPI staleness check. Intended for
   callers like `plan_check` that invoke `tf` many times per run and already perform their
   own check once at the top level.
+
+## \[0.10.28\] - 2026-07-18
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,28 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## \[0.10.28\] - 2026-07-18
+## \[0.10.29\] - 2026-07-20
+
+### Fixed
+
+- `convert_plan_to_json` retries `terraform show -json` once when the first attempt exits
+  without the FAILURE code but still produces no JSON. Observed intermittently in
+  amplify-education/terraform-config CI under `--parallel-jobs=16`, hitting a different
+  directory on different runs each time (never the same directory twice) — a same-input
+  retry reliably clears it. `extract_show_json`'s error message now also names the exit
+  code and explicitly flags a genuinely empty capture, instead of surfacing only whatever
+  noise (e.g. the version-staleness banner below) happened to precede the missing JSON.
+- `plan_check`'s nested `tf` subprocess calls (init, plan, and the show-to-JSON conversion)
+  now pass the new `tf --no-version-check` flag. Each of these calls previously re-ran its
+  own PyPI staleness check and printed a "Terrawrap is stale" banner to stderr, which
+  `execute_command`'s `capture_stderr=True` merges into the captured stdout — polluting
+  (and, in the failure above, dominating) the diagnostic output for real terraform errors.
+
+### Added
+
+- `tf --no-version-check`: skips the per-invocation PyPI staleness check. Intended for
+  callers like `plan_check` that invoke `tf` many times per run and already perform their
+  own check once at the top level.
 
 ### Changed
 

--- a/bin/plan_check
+++ b/bin/plan_check
@@ -38,7 +38,7 @@ from terrawrap.utils.config import (
     resolve_envvars,
 )
 from terrawrap.utils.git_utils import get_git_root
-from terrawrap.utils.plan import extract_show_json
+from terrawrap.utils.plan import PlanExitCode, convert_plan_to_json
 from terrawrap.utils.plan_check import (
     get_modified_subdirectories,
     is_plan_check_enabled,
@@ -56,12 +56,6 @@ class WrapperExitCode(Enum):
     SUCCESS = 0
     IAM_CHANGES = 2
     TERRAFORM_FAILURE = 3
-
-
-class PlanExitCode(Enum):
-    SUCCESS_NO_DIFF = 0
-    FAILURE = 1
-    SUCCESS_WITH_DIFF = 2
 
 
 def get_subdirectories(root_dir: str) -> Tuple[List[str], List[str]]:
@@ -83,50 +77,6 @@ def get_subdirectories(root_dir: str) -> Tuple[List[str], List[str]]:
             else:
                 regular_directories.append(current_dir)
     return regular_directories, symlinked_directories
-
-
-def convert_plan_to_json(
-    plan_binary_file: Path,
-    source_directory: Path,
-    additional_envvars: Dict[str, Optional[str]],
-) -> Path:
-    """
-    Converts binary terraform plan to json. Saves it in the same directory.
-    :param plan_binary_file: File with a plan saved in a binary format
-    :param source_directory: Directory with source terraform files
-    :param additional_envvars: A dictionary representing additional environment variables to supply
-    :return: Path object pointing to a json plan file
-    """
-    wrapper_py = os.path.join(SCRIPT_DIR, "tf")
-    command_env: Dict[str, Optional[str]] = dict(os.environ)
-    command_env.update(additional_envvars)
-
-    exit_code, stdout = execute_command(
-        [
-            wrapper_py,
-            source_directory.__str__(),
-            "show",
-            "-json",
-            str(plan_binary_file),
-        ],
-        print_output=False,
-        env=command_env,
-    )
-
-    if exit_code == PlanExitCode.FAILURE.value:
-        raise RuntimeError(f"'terraform show' failed for {plan_binary_file}:\n{''.join(stdout)}")
-
-    # `tf` echoes the command and execute_command merges stderr into stdout, so
-    # the captured stream may contain a command-echo line and any terraform
-    # warnings (lockfile, deprecations, etc.) before the JSON. Locate the JSON
-    # by content rather than trusting line counts.
-    show_json = extract_show_json(stdout)
-
-    plan_json_file = plan_binary_file.parent / "tfplan.json"
-    with plan_json_file.open("w") as plan_json_stream:
-        plan_json_stream.write(show_json)
-
-    return plan_json_file
 
 
 def init_and_plan_directory(
@@ -160,9 +110,12 @@ def init_and_plan_directory(
 
     # We're using --no-resolve-envvars here because we've already resolved the environment variables in
     # the constructor. We are then passing in those environment variables explicitly in the
-    # execute_command call below.
+    # execute_command call below. --no-version-check skips the per-invocation PyPI staleness
+    # check: plan_check makes dozens of these nested `tf` calls per run (see convert_plan_to_json),
+    # each of which would otherwise hit PyPI and print a stale-version nag merged into the
+    # captured stdout, obscuring real failures downstream.
     init_exit_code, init_stdout = execute_command(
-        [wrapper_py, "--no-resolve-envvars", directory, "init", "-upgrade"] + arguments,
+        [wrapper_py, "--no-resolve-envvars", "--no-version-check", directory, "init", "-upgrade"] + arguments,
         print_output=False,
         env=command_env,
     )
@@ -184,13 +137,12 @@ def init_and_plan_directory(
         plan_binary_file = plan_directory / "tfplan.binary"
         arguments.append(f"-out={plan_binary_file}")
 
-    # We're using --no-resolve-envvars here because we've already resolved the environment variables in
-    # the constructor. We are then passing in those environment variables explicitly in the
-    # execute_command call below.
+    # See the --no-version-check note on the init call above.
     plan_exit_code, plan_stdout = execute_command(
         [
             wrapper_py,
             "--no-resolve-envvars",
+            "--no-version-check",
             directory,
             "plan",
             "-detailed-exitcode",
@@ -215,6 +167,7 @@ def init_and_plan_directory(
                 plan_binary_file,
                 Path(directory),
                 additional_envvars,
+                wrapper_script=wrapper_py,
             )
         except RuntimeError as exception:
             print("\n".join(exception.args))

--- a/bin/tf
+++ b/bin/tf
@@ -2,7 +2,7 @@
 """Terraform Wrapper
 
 Usage:
-    tf [--no-resolve-envvars] (<tf_path> <tf_command>) [<additional_arguments>...]
+    tf [--no-resolve-envvars] [--no-version-check] (<tf_path> <tf_command>) [<additional_arguments>...]
     tf -h,--help
 
 Options:
@@ -11,6 +11,9 @@ Options:
     additional_arguments    Space separated arguments to pass to the wrapped terraform command. Ex: -lock=True
     -h,--help               Display this help message and quit.
     --no-resolve-envvars    Disable automatic resolution of envvars from .tf_wrapper files.
+    --no-version-check      Skip the PyPI staleness check for this invocation. Intended for callers
+                            (e.g. plan_check) that invoke `tf` many times per run and already perform
+                            their own version_check once.
 
 Examples:
     tf some/path/to/tf_files plan
@@ -236,6 +239,17 @@ def repush_state(path: str) -> bool:
     return False
 
 
+def should_skip_version_check(argv: List[str]) -> bool:
+    """
+    True if --no-version-check was passed as one of the leading optional flags.
+    Checked (and consumed from a copy of argv) ahead of process_arguments so
+    handler() can decide whether to call version_check before the rest of
+    argument parsing runs.
+    :param argv: The raw argument vector, e.g. sys.argv.
+    """
+    return "--no-version-check" in argv[1:3]
+
+
 def process_arguments(args: List[str]) -> Tuple[str, str, List[str], bool]:
     try:
         resolve_envvars = True
@@ -248,8 +262,11 @@ def process_arguments(args: List[str]) -> Tuple[str, str, List[str], bool]:
             print("Terrawrap %s" % __version__)
             sys.exit(0)
 
-        if args[1] in ["--no-resolve-envvars"]:
-            resolve_envvars = False
+        # Strip leading optional flags (order-independent) ahead of the required
+        # <tf_path> <tf_command> positionals.
+        while len(args) > 1 and args[1] in ("--no-resolve-envvars", "--no-version-check"):
+            if args[1] == "--no-resolve-envvars":
+                resolve_envvars = False
             args.pop(1)
 
         path = args[1]
@@ -263,7 +280,8 @@ def process_arguments(args: List[str]) -> Tuple[str, str, List[str], bool]:
 
 
 def handler():
-    version_check(current_version=__version__)
+    if not should_skip_version_check(sys.argv):
+        version_check(current_version=__version__)
     path, command, additional_arguments, should_resolve_envvars = process_arguments(sys.argv)
 
     tf_config_path = get_absolute_path(path=path)

--- a/bin/tf
+++ b/bin/tf
@@ -239,20 +239,10 @@ def repush_state(path: str) -> bool:
     return False
 
 
-def should_skip_version_check(argv: List[str]) -> bool:
-    """
-    True if --no-version-check was passed as one of the leading optional flags.
-    Checked (and consumed from a copy of argv) ahead of process_arguments so
-    handler() can decide whether to call version_check before the rest of
-    argument parsing runs.
-    :param argv: The raw argument vector, e.g. sys.argv.
-    """
-    return "--no-version-check" in argv[1:3]
-
-
-def process_arguments(args: List[str]) -> Tuple[str, str, List[str], bool]:
+def process_arguments(args: List[str]) -> Tuple[str, str, List[str], bool, bool]:
     try:
         resolve_envvars = True
+        skip_version_check = False
 
         if args[1] in ["-h", "--help"]:
             print(__doc__)
@@ -263,26 +253,33 @@ def process_arguments(args: List[str]) -> Tuple[str, str, List[str], bool]:
             sys.exit(0)
 
         # Strip leading optional flags (order-independent) ahead of the required
-        # <tf_path> <tf_command> positionals.
+        # <tf_path> <tf_command> positionals. This is the single place that
+        # recognizes these flags; callers (e.g. handler() below) act on the
+        # returned booleans rather than re-parsing argv themselves, so adding
+        # a third leading flag only means updating this loop.
         while len(args) > 1 and args[1] in ("--no-resolve-envvars", "--no-version-check"):
             if args[1] == "--no-resolve-envvars":
                 resolve_envvars = False
+            else:
+                skip_version_check = True
             args.pop(1)
 
         path = args[1]
         command = args[2]
         additional_arguments = args[3:]
 
-        return path, command, additional_arguments, resolve_envvars
+        return path, command, additional_arguments, resolve_envvars, skip_version_check
     except IndexError:
         print(__doc__)
         sys.exit(0)
 
 
 def handler():
-    if not should_skip_version_check(sys.argv):
+    path, command, additional_arguments, should_resolve_envvars, skip_version_check = process_arguments(
+        sys.argv
+    )
+    if not skip_version_check:
         version_check(current_version=__version__)
-    path, command, additional_arguments, should_resolve_envvars = process_arguments(sys.argv)
 
     tf_config_path = get_absolute_path(path=path)
 

--- a/terrawrap/utils/plan.py
+++ b/terrawrap/utils/plan.py
@@ -54,10 +54,10 @@ def convert_plan_to_json(
     """
     Converts binary terraform plan to json. Saves it in the same directory.
 
-    Retries the `terraform show -json` conversion once if the first attempt exits
-    without the FAILURE code but still produces no JSON — an intermittent failure
-    mode observed under high --parallel-jobs concurrency (see CHANGELOG) that a
-    same-input retry reliably clears.
+    Retries the `terraform show -json` conversion once if the first attempt exits 0
+    but still produces no JSON — an intermittent failure mode observed under high
+    --parallel-jobs concurrency (see CHANGELOG) that a same-input retry reliably
+    clears. Any non-zero exit is a hard failure and is never retried.
 
     :param plan_binary_file: File with a plan saved in a binary format
     :param source_directory: Directory with source terraform files
@@ -78,9 +78,15 @@ def convert_plan_to_json(
     ]
 
     def run_show() -> Tuple[List[str], int]:
+        # `terraform show` (unlike `terraform plan -detailed-exitcode`) only ever exits 0
+        # or 1 on success/failure, so PlanExitCode's plan-specific values (SUCCESS_WITH_DIFF)
+        # don't apply here. Anything other than a clean 0 exit is a hard failure raised
+        # immediately, not retried — only a 0 exit with no JSON is the known transient flake.
         exit_code, stdout = execute_command(show_command, print_output=False, env=command_env)
-        if exit_code == PlanExitCode.FAILURE.value:
-            raise RuntimeError(f"'terraform show' failed for {plan_binary_file}:\n{''.join(stdout)}")
+        if exit_code != 0:
+            raise RuntimeError(
+                f"'terraform show' failed for {plan_binary_file} (exit code {exit_code}):\n{''.join(stdout)}"
+            )
         return stdout, exit_code
 
     stdout, exit_code = run_show()

--- a/terrawrap/utils/plan.py
+++ b/terrawrap/utils/plan.py
@@ -1,9 +1,23 @@
 """Helpers for processing terraform plan output."""
 
-from typing import List
+import os
+import sys
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from terrawrap.utils.cli import execute_command
 
 
-def extract_show_json(stdout_lines: List[str]) -> str:
+class PlanExitCode(Enum):
+    """Exit codes produced by `terraform plan -detailed-exitcode`, reused for `show`."""
+
+    SUCCESS_NO_DIFF = 0
+    FAILURE = 1
+    SUCCESS_WITH_DIFF = 2
+
+
+def extract_show_json(stdout_lines: List[str], exit_code: Optional[int] = None) -> str:
     """
     Extract the JSON output of `terraform show -json` from a captured stdout
     stream that may contain non-JSON noise (the `tf` wrapper's command echo,
@@ -15,12 +29,74 @@ def extract_show_json(stdout_lines: List[str]) -> str:
 
     :param stdout_lines: Lines captured from the command's stdout, each
         retaining its trailing newline as returned by `readlines()`.
+    :param exit_code: The command's exit code, included in the error message
+        when raised so a caller can tell "exited 0 but wrote nothing" apart
+        from a non-FAILURE exit code that still produced no JSON.
     :return: The JSON content as a single string.
     :raises RuntimeError: If no JSON line is found.
     """
     for i, line in enumerate(stdout_lines):
         if line.lstrip().startswith("{"):
             return "".join(stdout_lines[i:])
-    raise RuntimeError(
-        f"no JSON object found in `terraform show -json` output: {''.join(stdout_lines[-50:])}"
-    )
+
+    code_note = f" (exit code {exit_code})" if exit_code is not None else ""
+    captured = "".join(stdout_lines[-50:]).strip()
+    body = captured if captured else "<no output captured>"
+    raise RuntimeError(f"no JSON object found in `terraform show -json` output{code_note}: {body}")
+
+
+def convert_plan_to_json(
+    plan_binary_file: Path,
+    source_directory: Path,
+    additional_envvars: Dict[str, Optional[str]],
+    wrapper_script: str,
+) -> Path:
+    """
+    Converts binary terraform plan to json. Saves it in the same directory.
+
+    Retries the `terraform show -json` conversion once if the first attempt exits
+    without the FAILURE code but still produces no JSON — an intermittent failure
+    mode observed under high --parallel-jobs concurrency (see CHANGELOG) that a
+    same-input retry reliably clears.
+
+    :param plan_binary_file: File with a plan saved in a binary format
+    :param source_directory: Directory with source terraform files
+    :param additional_envvars: A dictionary representing additional environment variables to supply
+    :param wrapper_script: Path to the `tf` wrapper executable to invoke `show -json` through
+    :return: Path object pointing to a json plan file
+    """
+    command_env: Dict[str, Optional[str]] = dict(os.environ)
+    command_env.update(additional_envvars)
+
+    show_command = [
+        wrapper_script,
+        "--no-version-check",
+        str(source_directory),
+        "show",
+        "-json",
+        str(plan_binary_file),
+    ]
+
+    def run_show() -> Tuple[List[str], int]:
+        exit_code, stdout = execute_command(show_command, print_output=False, env=command_env)
+        if exit_code == PlanExitCode.FAILURE.value:
+            raise RuntimeError(f"'terraform show' failed for {plan_binary_file}:\n{''.join(stdout)}")
+        return stdout, exit_code
+
+    stdout, exit_code = run_show()
+    try:
+        show_json = extract_show_json(stdout, exit_code=exit_code)
+    except RuntimeError as exception:
+        print(
+            f"Warning: retrying 'terraform show -json' for {plan_binary_file} "
+            f"after an empty conversion attempt: {exception}",
+            file=sys.stderr,
+        )
+        stdout, exit_code = run_show()
+        show_json = extract_show_json(stdout, exit_code=exit_code)
+
+    plan_json_file = plan_binary_file.parent / "tfplan.json"
+    with plan_json_file.open("w") as plan_json_stream:
+        plan_json_stream.write(show_json)
+
+    return plan_json_file

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.10.28"
+__version__ = "0.10.29"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_plan.py
+++ b/test/unit/test_plan.py
@@ -1,8 +1,12 @@
 """Tests for plan output processing helpers"""
 
+from pathlib import Path
 from unittest import TestCase
+from unittest.mock import patch
 
-from terrawrap.utils.plan import extract_show_json
+from terrawrap.utils.plan import PlanExitCode, convert_plan_to_json, extract_show_json
+
+MODULE = "terrawrap.utils.plan"
 
 
 class TestExtractShowJson(TestCase):
@@ -46,3 +50,101 @@ class TestExtractShowJson(TestCase):
         """Raises RuntimeError if there is no JSON line in stdout"""
         with self.assertRaises(RuntimeError):
             extract_show_json(["Executing: terraform show -json\n", "Error: no plan\n"])
+
+    def test_error_includes_exit_code_when_provided(self):
+        """The raised message names the exit code, not just the noise around it
+
+        Regression: a bare "no JSON object found ... output: <noise>" message
+        can't distinguish "terraform show exited 0 but wrote nothing" from a
+        real failure that happened to exit non-zero without the FAILURE code.
+        """
+        with self.assertRaisesRegex(RuntimeError, r"exit code 0"):
+            extract_show_json(["Executing: terraform show -json\n"], exit_code=0)
+
+    def test_error_notes_empty_output_when_nothing_captured(self):
+        """An empty/whitespace-only capture is reported explicitly, not as a blank suffix"""
+        with self.assertRaisesRegex(RuntimeError, r"<no output captured>"):
+            extract_show_json([], exit_code=0)
+
+
+@patch(f"{MODULE}.execute_command")
+class TestConvertPlanToJson(TestCase):
+    """Test convert_plan_to_json"""
+
+    def setUp(self):
+        self.plan_binary_file = Path("/tmp/tfplan/foo/tfplan.binary")
+        self.source_directory = Path("/repo/config/foo")
+
+    def _write_target(self):
+        """convert_plan_to_json writes tfplan.json next to the binary; avoid touching disk"""
+        return patch(f"{MODULE}.Path.open")
+
+    @patch.dict(f"{MODULE}.os.environ", {}, clear=True)
+    def test_writes_json_on_first_attempt(self, mock_execute):
+        """Writes the plan JSON and returns its path when show succeeds on the first try"""
+        mock_execute.return_value = (
+            PlanExitCode.SUCCESS_WITH_DIFF.value,
+            ["Executing: terraform show -json\n", '{"a":1}\n'],
+        )
+        with self._write_target() as mock_open:
+            result = convert_plan_to_json(
+                self.plan_binary_file, self.source_directory, {}, wrapper_script="/opt/bin/tf"
+            )
+            mock_open.return_value.__enter__.return_value.write.assert_called_once_with('{"a":1}\n')
+
+        self.assertEqual(result, self.plan_binary_file.parent / "tfplan.json")
+        mock_execute.assert_called_once_with(
+            [
+                "/opt/bin/tf",
+                "--no-version-check",
+                str(self.source_directory),
+                "show",
+                "-json",
+                str(self.plan_binary_file),
+            ],
+            print_output=False,
+            env={},
+        )
+
+    def test_retries_once_when_first_attempt_has_no_json(self, mock_execute):
+        """A single empty/noise-only attempt is retried and recovers transparently
+
+        Regression: amplify-education/terraform-config CI observed `terraform show
+        -json` intermittently returning only terrawrap's own noise (no JSON) under
+        --parallel-jobs=16, hitting a different directory on different runs. That's
+        the transient failure this retry is meant to absorb.
+        """
+        mock_execute.side_effect = [
+            (PlanExitCode.SUCCESS_WITH_DIFF.value, ["WARNING: Your version of Terrawrap is stale!\n"]),
+            (PlanExitCode.SUCCESS_WITH_DIFF.value, ['{"a":1}\n']),
+        ]
+        with self._write_target():
+            convert_plan_to_json(
+                self.plan_binary_file, self.source_directory, {}, wrapper_script="/opt/bin/tf"
+            )
+
+        self.assertEqual(mock_execute.call_count, 2)
+
+    def test_raises_after_second_attempt_still_has_no_json(self, mock_execute):
+        """Gives up after one retry rather than looping forever on a persistent failure"""
+        mock_execute.return_value = (
+            PlanExitCode.SUCCESS_WITH_DIFF.value,
+            ["WARNING: Your version of Terrawrap is stale!\n"],
+        )
+        with self.assertRaisesRegex(RuntimeError, r"no JSON object found"):
+            convert_plan_to_json(
+                self.plan_binary_file, self.source_directory, {}, wrapper_script="/opt/bin/tf"
+            )
+
+        self.assertEqual(mock_execute.call_count, 2)
+
+    def test_does_not_retry_on_terraform_show_failure(self, mock_execute):
+        """A genuine 'terraform show' failure (exit code FAILURE) is not treated as the
+        flaky empty-output case and is not retried"""
+        mock_execute.return_value = (PlanExitCode.FAILURE.value, ["Error: failed to read plan file\n"])
+        with self.assertRaisesRegex(RuntimeError, r"'terraform show' failed"):
+            convert_plan_to_json(
+                self.plan_binary_file, self.source_directory, {}, wrapper_script="/opt/bin/tf"
+            )
+
+        mock_execute.assert_called_once()

--- a/test/unit/test_plan.py
+++ b/test/unit/test_plan.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
-from terrawrap.utils.plan import PlanExitCode, convert_plan_to_json, extract_show_json
+from terrawrap.utils.plan import convert_plan_to_json, extract_show_json
 
 MODULE = "terrawrap.utils.plan"
 
@@ -82,10 +82,7 @@ class TestConvertPlanToJson(TestCase):
     @patch.dict(f"{MODULE}.os.environ", {}, clear=True)
     def test_writes_json_on_first_attempt(self, mock_execute):
         """Writes the plan JSON and returns its path when show succeeds on the first try"""
-        mock_execute.return_value = (
-            PlanExitCode.SUCCESS_WITH_DIFF.value,
-            ["Executing: terraform show -json\n", '{"a":1}\n'],
-        )
+        mock_execute.return_value = (0, ["Executing: terraform show -json\n", '{"a":1}\n'])
         with self._write_target() as mock_open:
             result = convert_plan_to_json(
                 self.plan_binary_file, self.source_directory, {}, wrapper_script="/opt/bin/tf"
@@ -115,8 +112,8 @@ class TestConvertPlanToJson(TestCase):
         the transient failure this retry is meant to absorb.
         """
         mock_execute.side_effect = [
-            (PlanExitCode.SUCCESS_WITH_DIFF.value, ["WARNING: Your version of Terrawrap is stale!\n"]),
-            (PlanExitCode.SUCCESS_WITH_DIFF.value, ['{"a":1}\n']),
+            (0, ["WARNING: Your version of Terrawrap is stale!\n"]),
+            (0, ['{"a":1}\n']),
         ]
         with self._write_target():
             convert_plan_to_json(
@@ -127,10 +124,7 @@ class TestConvertPlanToJson(TestCase):
 
     def test_raises_after_second_attempt_still_has_no_json(self, mock_execute):
         """Gives up after one retry rather than looping forever on a persistent failure"""
-        mock_execute.return_value = (
-            PlanExitCode.SUCCESS_WITH_DIFF.value,
-            ["WARNING: Your version of Terrawrap is stale!\n"],
-        )
+        mock_execute.return_value = (0, ["WARNING: Your version of Terrawrap is stale!\n"])
         with self.assertRaisesRegex(RuntimeError, r"no JSON object found"):
             convert_plan_to_json(
                 self.plan_binary_file, self.source_directory, {}, wrapper_script="/opt/bin/tf"
@@ -139,10 +133,25 @@ class TestConvertPlanToJson(TestCase):
         self.assertEqual(mock_execute.call_count, 2)
 
     def test_does_not_retry_on_terraform_show_failure(self, mock_execute):
-        """A genuine 'terraform show' failure (exit code FAILURE) is not treated as the
+        """A genuine 'terraform show' failure (nonzero exit) is not treated as the
         flaky empty-output case and is not retried"""
-        mock_execute.return_value = (PlanExitCode.FAILURE.value, ["Error: failed to read plan file\n"])
+        mock_execute.return_value = (1, ["Error: failed to read plan file\n"])
         with self.assertRaisesRegex(RuntimeError, r"'terraform show' failed"):
+            convert_plan_to_json(
+                self.plan_binary_file, self.source_directory, {}, wrapper_script="/opt/bin/tf"
+            )
+
+        mock_execute.assert_called_once()
+
+    def test_does_not_retry_on_nonstandard_exit_code(self, mock_execute):
+        """A non-zero, non-1 exit (e.g. a signal kill) is also a hard failure, not the flake
+
+        Regression: retrying on anything other than a genuinely clean 0 exit risks masking a
+        real, non-transient failure (wrapper crash, OOM kill, timeout) behind a second identical
+        subprocess round-trip before the error is ever surfaced.
+        """
+        mock_execute.return_value = (137, ["Killed\n"])
+        with self.assertRaisesRegex(RuntimeError, r"exit code 137"):
             convert_plan_to_json(
                 self.plan_binary_file, self.source_directory, {}, wrapper_script="/opt/bin/tf"
             )

--- a/test/unit/test_plan_check_bin.py
+++ b/test/unit/test_plan_check_bin.py
@@ -1,0 +1,53 @@
+"""Tests for bin/plan_check's nested `tf` subprocess invocations"""
+
+import importlib.machinery
+import importlib.util
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+_BIN_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "bin", "plan_check"))
+
+
+def _load_plan_check_module():
+    """Load bin/plan_check (no .py extension) as a module via SourceFileLoader."""
+    loader = importlib.machinery.SourceFileLoader("plan_check_bin", _BIN_PATH)
+    spec = importlib.util.spec_from_loader("plan_check_bin", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+class TestInitAndPlanDirectoryNoVersionCheck(TestCase):
+    """init_and_plan_directory's nested `tf` calls skip the per-invocation version check"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_plan_check_module()
+
+    def test_init_and_plan_calls_pass_no_version_check(self):
+        """Both the init and plan subprocess calls include --no-version-check
+
+        plan_check makes one nested `tf` call per directory for init, plan, and
+        (when writing plan output) show; each independently re-runs the PyPI
+        staleness check unless told not to, polluting captured stdout with a
+        nag banner that has obscured real terraform show failures in CI.
+        """
+        with patch.object(self.mod, "execute_command") as mock_execute:
+            mock_execute.side_effect = [
+                (0, ["init ok\n"]),
+                (self.mod.PlanExitCode.SUCCESS_NO_DIFF.value, ["plan ok\n"]),
+            ]
+            result = self.mod.init_and_plan_directory(
+                directory="/tmp/does-not-exist",
+                skip_iam=True,
+                print_diff=False,
+                with_colors=False,
+                additional_envvars={},
+            )
+
+        self.assertEqual(result, self.mod.WrapperExitCode.SUCCESS)
+        self.assertEqual(mock_execute.call_count, 2)
+        for call in mock_execute.call_args_list:
+            command_args = call.args[0]
+            self.assertIn("--no-version-check", command_args)

--- a/test/unit/test_tf_bin.py
+++ b/test/unit/test_tf_bin.py
@@ -17,29 +17,8 @@ def _load_tf_module():
     return mod
 
 
-class TestShouldSkipVersionCheck(TestCase):
-    """Test should_skip_version_check"""
-
-    @classmethod
-    def setUpClass(cls):
-        cls.mod = _load_tf_module()
-
-    def test_true_when_flag_is_first(self):
-        """Detects --no-version-check as the leading flag"""
-        self.assertTrue(self.mod.should_skip_version_check(["tf", "--no-version-check", "dir", "plan"]))
-
-    def test_true_when_flag_follows_no_resolve_envvars(self):
-        """Detects --no-version-check when combined with --no-resolve-envvars, in either order"""
-        argv = ["tf", "--no-resolve-envvars", "--no-version-check", "dir", "plan"]
-        self.assertTrue(self.mod.should_skip_version_check(argv))
-
-    def test_false_when_flag_absent(self):
-        """A normal invocation with no flags does not skip the version check"""
-        self.assertFalse(self.mod.should_skip_version_check(["tf", "dir", "plan"]))
-
-
 class TestProcessArguments(TestCase):
-    """Test process_arguments strips leading optional flags in any combination"""
+    """process_arguments strips leading optional flags, in any combination, in one pass"""
 
     @classmethod
     def setUpClass(cls):
@@ -47,25 +26,22 @@ class TestProcessArguments(TestCase):
 
     def test_no_flags(self):
         """Parses path/command/arguments with no optional flags present"""
-        path, command, additional_arguments, resolve_envvars = self.mod.process_arguments(
-            ["tf", "dir", "plan", "-lock=false"]
-        )
-        self.assertEqual(
-            (path, command, additional_arguments, resolve_envvars), ("dir", "plan", ["-lock=false"], True)
-        )
+        result = self.mod.process_arguments(["tf", "dir", "plan", "-lock=false"])
+        self.assertEqual(result, ("dir", "plan", ["-lock=false"], True, False))
 
     def test_no_version_check_flag_alone(self):
-        """--no-version-check is stripped and does not disable envvar resolution"""
-        path, command, additional_arguments, resolve_envvars = self.mod.process_arguments(
-            ["tf", "--no-version-check", "dir", "plan"]
-        )
-        self.assertEqual((path, command, additional_arguments, resolve_envvars), ("dir", "plan", [], True))
+        """--no-version-check is stripped, reported, and does not disable envvar resolution"""
+        result = self.mod.process_arguments(["tf", "--no-version-check", "dir", "plan"])
+        self.assertEqual(result, ("dir", "plan", [], True, True))
+
+    def test_no_resolve_envvars_flag_alone(self):
+        """--no-resolve-envvars is stripped and reported without affecting the version check"""
+        result = self.mod.process_arguments(["tf", "--no-resolve-envvars", "dir", "plan"])
+        self.assertEqual(result, ("dir", "plan", [], False, False))
 
     def test_both_flags_together(self):
-        """Both leading flags are stripped and resolve_envvars reflects --no-resolve-envvars"""
-        path, command, additional_arguments, resolve_envvars = self.mod.process_arguments(
+        """Both leading flags are stripped and both booleans reflect the flags passed"""
+        result = self.mod.process_arguments(
             ["tf", "--no-resolve-envvars", "--no-version-check", "dir", "init", "-upgrade"]
         )
-        self.assertEqual(
-            (path, command, additional_arguments, resolve_envvars), ("dir", "init", ["-upgrade"], False)
-        )
+        self.assertEqual(result, ("dir", "init", ["-upgrade"], False, True))

--- a/test/unit/test_tf_bin.py
+++ b/test/unit/test_tf_bin.py
@@ -1,0 +1,71 @@
+"""Tests for bin/tf's argument parsing, incl. --no-version-check"""
+
+import importlib.machinery
+import importlib.util
+import os
+from unittest import TestCase
+
+_BIN_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "bin", "tf"))
+
+
+def _load_tf_module():
+    """Load bin/tf (no .py extension) as a module via SourceFileLoader."""
+    loader = importlib.machinery.SourceFileLoader("tf_bin", _BIN_PATH)
+    spec = importlib.util.spec_from_loader("tf_bin", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+class TestShouldSkipVersionCheck(TestCase):
+    """Test should_skip_version_check"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_tf_module()
+
+    def test_true_when_flag_is_first(self):
+        """Detects --no-version-check as the leading flag"""
+        self.assertTrue(self.mod.should_skip_version_check(["tf", "--no-version-check", "dir", "plan"]))
+
+    def test_true_when_flag_follows_no_resolve_envvars(self):
+        """Detects --no-version-check when combined with --no-resolve-envvars, in either order"""
+        argv = ["tf", "--no-resolve-envvars", "--no-version-check", "dir", "plan"]
+        self.assertTrue(self.mod.should_skip_version_check(argv))
+
+    def test_false_when_flag_absent(self):
+        """A normal invocation with no flags does not skip the version check"""
+        self.assertFalse(self.mod.should_skip_version_check(["tf", "dir", "plan"]))
+
+
+class TestProcessArguments(TestCase):
+    """Test process_arguments strips leading optional flags in any combination"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_tf_module()
+
+    def test_no_flags(self):
+        """Parses path/command/arguments with no optional flags present"""
+        path, command, additional_arguments, resolve_envvars = self.mod.process_arguments(
+            ["tf", "dir", "plan", "-lock=false"]
+        )
+        self.assertEqual(
+            (path, command, additional_arguments, resolve_envvars), ("dir", "plan", ["-lock=false"], True)
+        )
+
+    def test_no_version_check_flag_alone(self):
+        """--no-version-check is stripped and does not disable envvar resolution"""
+        path, command, additional_arguments, resolve_envvars = self.mod.process_arguments(
+            ["tf", "--no-version-check", "dir", "plan"]
+        )
+        self.assertEqual((path, command, additional_arguments, resolve_envvars), ("dir", "plan", [], True))
+
+    def test_both_flags_together(self):
+        """Both leading flags are stripped and resolve_envvars reflects --no-resolve-envvars"""
+        path, command, additional_arguments, resolve_envvars = self.mod.process_arguments(
+            ["tf", "--no-resolve-envvars", "--no-version-check", "dir", "init", "-upgrade"]
+        )
+        self.assertEqual(
+            (path, command, additional_arguments, resolve_envvars), ("dir", "init", ["-upgrade"], False)
+        )


### PR DESCRIPTION
## Summary

`plan_check`'s `terraform show -json` conversion step intermittently comes back with no JSON payload under `--parallel-jobs=16`. Traced this from a real terraform-config CI failure ([amplify-education/terraform-config#38859](https://github.com/amplify-education/terraform-config/pull/38859)): terraform itself planned the directory successfully, but the JSON conversion right after came back empty except for terrawrap's own "your version is stale" nag banner — and the resulting error message was dominated by that banner, hiding what actually happened. Checked CI history and found the same signature on an earlier PR, hitting a *different* directory that time — confirming this is a pipeline-level flake, not a per-directory problem.

- `convert_plan_to_json` now retries the `show -json` conversion once when the first attempt exits without the `FAILURE` code but still produces no JSON. A genuine `'terraform show' failed` (FAILURE exit code) is never retried.
- `extract_show_json`'s error message now names the exit code and explicitly flags a truly empty capture, instead of surfacing only whatever noise happened to precede the missing JSON.
- Added `tf --no-version-check`, and `plan_check`'s nested `tf` calls (init, plan, show) now pass it. Each of these calls previously re-ran its own PyPI staleness check and printed a nag banner to stderr, which `execute_command`'s `capture_stderr=True` merges into captured stdout — this is exactly what dominated the misleading error in the original incident.

## Test plan
- [x] Added/updated unit tests: `test/unit/test_plan.py` (retry behavior, error message content), `test/unit/test_tf_bin.py` (flag parsing), `test/unit/test_plan_check_bin.py` (nested `tf` calls include the new flag)
- [x] Full suite: `pytest --cov=terrawrap test/unit` — 158 passed, 100% coverage on `terrawrap/utils/plan.py`
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy` clean on touched files (pre-existing unrelated errors in `git_utils.py` confirmed present on `main`)
- [x] Re-ran the originally-failing terraform-config CI job — passed on retry, confirming the flake theory

Terraform-config pins `terrawrap>=0.10.21,<0.11`, so this targets the 0.10.x line (bumped to 0.10.29) rather than the `release/0.11` branch, which is a stale divergent fork missing some fixes already on `main`.