### PR TITLE
Support a list of audit API URLs in audit_api_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## \[0.11.4\] - 2026-07-23
+
+### Added
+
+- `audit_api_url` in `.tf_wrapper` now also accepts a list of URLs. Each apply/destroy
+  posts its audit info (initial "in progress" and the final status update) to every URL
+  in the list; a failure posting to one URL is logged and does not block the others.
+  A scalar value keeps the existing single-URL behavior. This lets an environment
+  report applies to more than one terraform-audit-api instance (e.g. devops-testing
+  applies feeding both the devops-testing and devops audit APIs).
+
 ## \[0.11.3\] - 2026-07-21
 
 ### Changed

--- a/bin/tf
+++ b/bin/tf
@@ -28,7 +28,7 @@ import re
 import shutil
 import sys
 from datetime import datetime, timedelta
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 import boto3
 from dateutil.parser import parse
@@ -95,7 +95,7 @@ def exec_tf_command(
     variables: Dict[str, str],
     arguments: List[str],
     additional_envvars: Dict[str, str],
-    audit_api_url: str,
+    audit_api_url: Optional[Union[str, List[str]]],
 ):
     variable_envvars = convert_variables_to_envvars(variables=variables)
 

--- a/terrawrap/models/wrapper_config.py
+++ b/terrawrap/models/wrapper_config.py
@@ -137,6 +137,23 @@ def env_var_deserializer(obj_dict, cls, **kwargs):
 jsons.set_deserializer(env_var_deserializer, AbstractEnvVarConfig)
 
 
+class AuditApiUrls(List[str]):
+    """List of audit API URLs; deserializes from a scalar URL or a list of URLs."""
+
+
+# pylint: disable=unused-argument
+def audit_api_urls_deserializer(obj, cls, **kwargs):
+    """Normalize the YAML ``audit_api_url`` value to a list of URL strings."""
+    if isinstance(obj, str):
+        return AuditApiUrls([obj])
+    if isinstance(obj, list) and all(isinstance(url, str) for url in obj):
+        return AuditApiUrls(obj)
+    raise TypeError(f"audit_api_url must be a string or list of strings, got {obj!r}")
+
+
+jsons.set_deserializer(audit_api_urls_deserializer, AuditApiUrls)
+
+
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 class WrapperConfig:
     def __init__(
@@ -149,7 +166,7 @@ class WrapperConfig:
         backends: Optional[BackendsConfig] = None,
         depends_on: Optional[List[str]] = None,
         config: bool = True,
-        audit_api_url: Optional[str] = None,
+        audit_api_url: Optional[AuditApiUrls] = None,
         apply_automatically: bool = True,
         plugins: Optional[Dict[str, str]] = None,
     ):
@@ -161,6 +178,11 @@ class WrapperConfig:
         self.backends = backends
         self.depends_on = depends_on
         self.config = config
+        # Normalize so consumers always see a list of URLs (or None); direct
+        # construction with a plain string or list is normalized the same way
+        # the AuditApiUrls deserializer normalizes YAML values.
+        if audit_api_url is not None and not isinstance(audit_api_url, list):
+            audit_api_url = AuditApiUrls([audit_api_url])
         self.audit_api_url = audit_api_url
         self.apply_automatically = apply_automatically
         self.plugins = plugins or {}

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -65,7 +65,7 @@ def execute_command(
     print_command: bool = False,
     retry: bool = False,
     timeout: int = 15 * 60,
-    audit_api_url: Optional[str] = None,
+    audit_api_url: Optional[Union[str, List[str]]] = None,
     **kwargs,
 ) -> Tuple[int, List[str]]:
     """
@@ -77,11 +77,14 @@ def execute_command(
     :param print_command: True if the command should be printed before executing. Defaults to False.
     :param timeout: Max amount of time to keep retrying to execute command. Defaults to 15 minutes.
     :param retry: Retry a number of times if network errors. Defaults to False.
-    :param audit_api_url: Audit API URL to submit POST request. Defaults to None so no data is sent.
+    :param audit_api_url: Audit API URL(s) to submit POST requests to. Accepts a single URL or a list
+    of URLs; each URL receives the same audit info. Defaults to None so no data is sent.
     :param kwargs: Any additional keyword arguments to Popen.
     :return: A tuple of the exit code and output of the command.
     """
     try_count = 0
+
+    audit_api_urls = [audit_api_url] if isinstance(audit_api_url, str) else list(audit_api_url or [])
 
     # It's possible for an envvar to be set to none, so exclude those envvars.
     if "env" in kwargs:
@@ -90,16 +93,17 @@ def execute_command(
     # Get time - nanoseconds since epoch
     start_time = int(time.time())
 
-    if audit_api_url and kwargs["cwd"] and ("apply" in args or "destroy" in args):
-        try:
-            # Call _post_audit_info for working directory, setting status to 'in progress'
-            _post_audit_info(
-                audit_api_url=audit_api_url,
-                path=kwargs["cwd"],
-                start_time=start_time,
-            )
-        except HTTPError as http_exception:
-            logger.error("An error occurred while connecting to audit API: %s", http_exception)
+    if audit_api_urls and kwargs["cwd"] and ("apply" in args or "destroy" in args):
+        for url in audit_api_urls:
+            try:
+                # Call _post_audit_info for working directory, setting status to 'in progress'
+                _post_audit_info(
+                    audit_api_url=url,
+                    path=kwargs["cwd"],
+                    start_time=start_time,
+                )
+            except HTTPError as http_exception:
+                logger.error("An error occurred while connecting to audit API: %s", http_exception)
 
     else:
         logger.info("No audit_api_url provided")
@@ -136,19 +140,20 @@ def execute_command(
 
         time_passed = jitter.backoff()
 
-    if audit_api_url and kwargs["cwd"] and ("apply" in args or "destroy" in args):
+    if audit_api_urls and kwargs["cwd"] and ("apply" in args or "destroy" in args):
         # Call _post_audit_info again, this time to update the 'in progress' entry with new status and output
-        try:
-            _post_audit_info(
-                audit_api_url=audit_api_url,
-                path=kwargs["cwd"],
-                exit_code=exit_code,
-                stdout=stdout,
-                start_time=start_time,
-                update=True,
-            )
-        except HTTPError as http_exception:
-            logger.error("An error occurred while connecting to audit API: %s", http_exception)
+        for url in audit_api_urls:
+            try:
+                _post_audit_info(
+                    audit_api_url=url,
+                    path=kwargs["cwd"],
+                    exit_code=exit_code,
+                    stdout=stdout,
+                    start_time=start_time,
+                    update=True,
+                )
+            except HTTPError as http_exception:
+                logger.error("An error occurred while connecting to audit API: %s", http_exception)
     else:
         logger.info("No audit_api_url provided")
 

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.11.3"
+__version__ = "0.11.4"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -115,6 +115,41 @@ class TestCli(TestCase):
 
         mock_logger.assert_has_calls(expected_calls)
 
+    @patch("terrawrap.utils.cli._post_audit_info")
+    def test_execute_command_multiple_audit_urls(self, mock_audit_info):
+        """A list of audit API URLs posts the initial and update audit info to every URL."""
+        self.mock_process.poll.return_value = 0
+        urls = ["https://audit-a.example.com", "https://audit-b.example.com"]
+
+        exit_code, _ = execute_command(["apply", "1"], audit_api_url=urls, cwd=os.getcwd())
+
+        self.assertEqual(exit_code, 0)
+        posted_urls = [c.kwargs["audit_api_url"] for c in mock_audit_info.call_args_list]
+        # Initial 'in progress' post to each URL, then the status update to each URL.
+        self.assertEqual(urls + urls, posted_urls)
+        for update_call in mock_audit_info.call_args_list[2:]:
+            self.assertTrue(update_call.kwargs["update"])
+
+    @patch.object(Logger, "error")
+    @patch("terrawrap.utils.cli._post_audit_info")
+    def test_execute_command_multi_url_one_fails(self, mock_audit_info, mock_logger):
+        """A failing audit URL is logged and does not block posting to the remaining URLs."""
+        self.mock_process.poll.return_value = 0
+        urls = ["https://audit-a.example.com", "https://audit-b.example.com"]
+        mock_audit_info.side_effect = [MOCK_ERROR, None, MOCK_ERROR, None]
+
+        exit_code, _ = execute_command(["apply", "1"], audit_api_url=urls, cwd=os.getcwd())
+
+        self.assertEqual(exit_code, 0)
+        posted_urls = [c.kwargs["audit_api_url"] for c in mock_audit_info.call_args_list]
+        self.assertEqual(urls + urls, posted_urls)
+        mock_logger.assert_has_calls(
+            [
+                call("An error occurred while connecting to audit API: %s", MOCK_ERROR),
+                call("An error occurred while connecting to audit API: %s", MOCK_ERROR),
+            ]
+        )
+
     @patch("terrawrap.utils.cli.BotoAWSRequestsAuth")
     @patch("requests.post")
     def test_post_audit_info_statuses(self, mock_post, _):

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -412,6 +412,78 @@ class TestPathMergeSemantics(TestCase):
         self.assertEqual(["/account/app_auth/github/terraform_token"], envvar.paths)
 
 
+class TestAuditApiUrlParsing(TestCase):
+    """Verify audit_api_url accepts a scalar URL or a list of URLs."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="terrawrap_audit_url_")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write(self, rel_path: str, body: str) -> str:
+        abs_path = os.path.join(self.tmpdir, rel_path)
+        os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+        with open(abs_path, "w", encoding="utf-8") as handle:
+            handle.write(textwrap.dedent(body).lstrip())
+        return abs_path
+
+    def test_scalar_url(self):
+        """A scalar audit_api_url deserializes as a single-element list."""
+        parent = self._write(
+            "parent/.tf_wrapper",
+            """
+            audit_api_url: https://audit.example.com
+            """,
+        )
+
+        config = parse_wrapper_configs([parent])
+
+        self.assertEqual(["https://audit.example.com"], config.audit_api_url)
+
+    def test_list_of_urls(self):
+        """A list audit_api_url deserializes as a list of strings."""
+        parent = self._write(
+            "parent/.tf_wrapper",
+            """
+            audit_api_url:
+              - https://audit-a.example.com
+              - https://audit-b.example.com
+            """,
+        )
+
+        config = parse_wrapper_configs([parent])
+
+        self.assertEqual(
+            ["https://audit-a.example.com", "https://audit-b.example.com"],
+            config.audit_api_url,
+        )
+
+    def test_child_list_replaces_parent_scalar(self):
+        """A child list overrides a parent scalar without a type-mismatch crash."""
+        parent = self._write(
+            "parent/.tf_wrapper",
+            """
+            audit_api_url: https://parent.example.com
+            """,
+        )
+        child = self._write(
+            "parent/child/.tf_wrapper",
+            """
+            audit_api_url:
+              - https://child-a.example.com
+              - https://child-b.example.com
+            """,
+        )
+
+        config = parse_wrapper_configs([parent, child])
+
+        self.assertEqual(
+            ["https://child-a.example.com", "https://child-b.example.com"],
+            config.audit_api_url,
+        )
+
+
 class TestSiblingIsolation(TestCase):
     """Regression tests proving child .tf_wrappers cannot leak into sibling subtrees."""
 

--- a/test/unit/test_real_world_compat.py
+++ b/test/unit/test_real_world_compat.py
@@ -45,7 +45,7 @@ class TestRootConfigWrapper(_WrapperFixtureCase):
     """Pattern: top-level config/.tf_wrapper with audit_api_url + a text envvar."""
 
     def test_root_config_parses(self):
-        """audit_api_url is preserved and a scalar text envvar resolves verbatim."""
+        """audit_api_url normalizes to a URL list and a scalar text envvar resolves verbatim."""
         wrapper = self._write(
             "config/.tf_wrapper",
             """
@@ -59,7 +59,7 @@ class TestRootConfigWrapper(_WrapperFixtureCase):
 
         config = parse_wrapper_configs([wrapper])
 
-        self.assertEqual("https://terraform-audit-api.devops.amplify.com", config.audit_api_url)
+        self.assertEqual(["https://terraform-audit-api.devops.amplify.com"], config.audit_api_url)
         self.assertIsInstance(config.envvars["GITHUB_OWNER"], TextEnvVarConfig)
         self.assertEqual("amplify-education", config.envvars["GITHUB_OWNER"].value)
 


### PR DESCRIPTION
- `audit_api_url` in `.tf_wrapper` now accepts a list of URLs in addition to a scalar; each apply/destroy posts its audit info (initial "in progress" and final status update) to every URL, and a failure posting to one URL is logged without blocking the others.
- Deserialization uses a new `AuditApiUrls` type with a custom jsons deserializer (a `Union[str, List[str]]` hint stringifies lists); `WrapperConfig.audit_api_url` is now always a `List[str]` or `None`.
- Releases as 0.11.4 so amplify-education/terraform-config (pinned `<0.12`) picks it up; needed so the devops-testing environment can report applies to both the devops-testing and devops terraform-audit-api instances.

## Test plan

- New unit tests: scalar/list/parent-child-override parsing, multi-URL posting on apply, and one-URL-failure isolation.
- `tox` green on py310–py314 (162 tests); pre-commit (ruff + mypy) clean.
- Manually parsed the real terraform-config root + amplify-devops-testing `.tf_wrapper` chain with this build: merged config yields both URLs, root-only yields the single devops URL.