### PR TITLE
feat: add a `command` envvar source to .tf_wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -410,6 +410,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Remove duplicate TF Audit calls from `graph_entry`; the inner `bin/tf`
   invocation already records the apply. (AT-7866, PR #160)
 
+## \[0.12.0\] - 2026-07-27
+
+### Added
+
+- New `command` envvar source for `.tf_wrapper`. The named command runs from the repo root and its stdout
+  becomes the environment variable's value, so credentials that must be minted per run no longer have to be
+  stored anywhere. A non-zero exit, a timeout (default 30s), or an unrunnable command is a hard error.
+
 ## \[0.9.20\] - 2022-09-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## \[0.12.0\] - 2026-07-27
+
+### Added
+
+- New `command` envvar source for `.tf_wrapper`. The named command runs from the root of the repo holding
+  the config directory and its stdout becomes the environment variable's value, so credentials that must be
+  minted per run no longer have to be stored anywhere. A non-zero exit, a timeout (default 30s), or an
+  unrunnable command is a hard error.
+
 ## \[0.11.4\] - 2026-07-23
 
 ### Added
@@ -409,14 +418,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Remove duplicate TF Audit calls from `graph_entry`; the inner `bin/tf`
   invocation already records the apply. (AT-7866, PR #160)
-
-## \[0.12.0\] - 2026-07-27
-
-### Added
-
-- New `command` envvar source for `.tf_wrapper`. The named command runs from the repo root and its stdout
-  becomes the environment variable's value, so credentials that must be minted per run no longer have to be
-  stored anywhere. A non-zero exit, a timeout (default 30s), or an unrunnable command is a hard error.
 
 ## \[0.9.20\] - 2022-09-23
 

--- a/README.md
+++ b/README.md
@@ -138,10 +138,12 @@ backend_check: True # If true, require this directory to have a terraform backen
 
 envvars:
   <NAME_OF_ENVVAR>:
-    source: # The source of the envvar. One of `['ssm', 'text', 'unset']`.
+    source: # The source of the envvar. One of `['ssm', 'text', 'unset', 'command']`.
     path: # If source is `ssm`, the SSM Parameter Store path to read the value from. May be a single string or a list of strings (ordered fallbacks).
     value: # if the source of the envvar is `text`, the string value to set as the environment variable.
     # If the source is unset, any previous value for the environment variable is removed and the environment variable will not be set.
+    command: # If source is `command`, the argument vector to run. The command's stdout becomes the value.
+    timeout: # If source is `command`, seconds to allow the command to run. Defaults to 30.
 
 plugins:
     <NAME_OF_PLUGIN>: <plugin url>
@@ -162,6 +164,32 @@ envvars:
       - /account/app_auth/github/terraform_token
       - /shared/github/terraform_token
 ```
+
+### `command` envvars
+
+A `command` envvar runs a command and uses its stdout, stripped of surrounding
+whitespace, as the value. This suits credentials that must be minted per run
+rather than stored — a short-lived token exchanged from the caller's existing
+identity, for example.
+
+```yaml
+envvars:
+  CONSUL_HTTP_TOKEN:
+    source: command
+    command: ["clis/consul_login.py", "--print-token"]
+    timeout: 60
+```
+
+- `command` must be an argument vector, not a string. Commands run without a
+  shell, so pipes, redirection, and quoting are not interpreted; a string is
+  rejected rather than split.
+- Commands run with the **root of the git repo** as their working directory, so
+  they can be written relative to it no matter which config directory terrawrap
+  was pointed at.
+- A non-zero exit, a timeout, or a command that cannot be run is a hard error
+  naming the envvar — it never resolves to an empty value.
+- Envvars resolve on every terrawrap invocation, so a command that is slow or
+  rate-limited should cache its own result.
 
 ### Plugins
 

--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ envvars:
 - `command` must be an argument vector, not a string. Commands run without a
   shell, so pipes, redirection, and quoting are not interpreted; a string is
   rejected rather than split.
-- Commands run with the **root of the git repo** as their working directory, so
-  they can be written relative to it no matter which config directory terrawrap
-  was pointed at.
+- Commands run with the **root of the git repo holding the config directory** as
+  their working directory, so they can be written relative to it no matter which
+  config directory terrawrap was pointed at, or where terrawrap was invoked from.
 - A non-zero exit, a timeout, or a command that cannot be run is a hard error
   naming the envvar — it never resolves to an empty value.
 - Envvars resolve on every terrawrap invocation, so a command that is slow or

--- a/terrawrap/exceptions.py
+++ b/terrawrap/exceptions.py
@@ -9,3 +9,7 @@ class NotTerraformConfigDirectory(RuntimeError):
 
 class NoDependency(Exception):
     """Error raised when processing a directory that contains .tf_wrapper config files with no dependency"""
+
+
+class EnvVarResolutionError(RuntimeError):
+    """Error raised when a .tf_wrapper envvar cannot be resolved to a value"""

--- a/terrawrap/models/graph_entry.py
+++ b/terrawrap/models/graph_entry.py
@@ -50,7 +50,7 @@ class GraphEntry(Entry):
         self.abs_path = get_absolute_path(path=path)
         wrapper_config_files = find_wrapper_config_files(self.abs_path)
         self.wrapper_config = parse_wrapper_configs(wrapper_config_files)
-        self.envvars = resolve_envvars(self.wrapper_config.envvars)
+        self.envvars = resolve_envvars(self.wrapper_config.envvars, self.abs_path)
         self.variables = variables
         self.state = "Pending"
 

--- a/terrawrap/models/pipeline_entry.py
+++ b/terrawrap/models/pipeline_entry.py
@@ -27,7 +27,7 @@ class PipelineEntry:
         self.path = get_absolute_path(path=path)
         wrapper_config_files = find_wrapper_config_files(self.path)
         wrapper_config = parse_wrapper_configs(wrapper_config_files)
-        self.envvars = resolve_envvars(wrapper_config.envvars)
+        self.envvars = resolve_envvars(wrapper_config.envvars, self.path)
         self.variables = variables
 
     # pylint: disable=too-many-locals

--- a/terrawrap/models/wrapper_config.py
+++ b/terrawrap/models/wrapper_config.py
@@ -7,11 +7,14 @@ from typing import Dict, List, Optional
 
 import jsons
 
+DEFAULT_COMMAND_TIMEOUT = 30
+
 
 class EnvVarSource(Enum):
     SSM = "ssm"
     TEXT = "text"
     UNSET = "unset"
+    COMMAND = "command"
 
 
 class AbstractEnvVarConfig:
@@ -44,6 +47,15 @@ class TextEnvVarConfig(AbstractEnvVarConfig):
 class UnsetEnvVarConfig(AbstractEnvVarConfig):
     def __init__(self):
         super().__init__(EnvVarSource.UNSET)
+
+
+class CommandEnvVarConfig(AbstractEnvVarConfig):
+    def __init__(self, command: List[str], timeout: int = DEFAULT_COMMAND_TIMEOUT):
+        if not command:
+            raise ValueError("CommandEnvVarConfig requires at least one command argument")
+        super().__init__(EnvVarSource.COMMAND)
+        self.command = command
+        self.timeout = timeout
 
 
 class S3BackendConfig:
@@ -121,6 +133,35 @@ def _ssm_paths_from_dict(obj_dict: Dict) -> List[str]:
     return paths
 
 
+def _parse_command_args(raw) -> List[str]:
+    """Validate a YAML ``command`` value as a non-empty argument vector.
+
+    A bare string is rejected rather than split: the command runs without a
+    shell, so accepting one would silently mis-parse quoting and pipes.
+    """
+    if isinstance(raw, str):
+        raise TypeError(
+            f"command envvar 'command' must be a list of arguments, not a string, got {raw!r}. "
+            "The command runs without a shell, so quoting and pipes are not interpreted."
+        )
+    if not isinstance(raw, list):
+        raise TypeError(f"command envvar 'command' must be a list of strings, got {raw!r}")
+    if not raw:
+        raise ValueError("command envvar 'command' list must not be empty")
+    if not all(isinstance(arg, str) for arg in raw):
+        raise TypeError(f"command envvar 'command' must be a list of strings, got {raw!r}")
+    return list(raw)
+
+
+def _parse_timeout(raw) -> int:
+    """Validate a YAML ``timeout`` value as a positive number of seconds."""
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        raise TypeError(f"command envvar 'timeout' must be an integer, got {raw!r}")
+    if raw <= 0:
+        raise ValueError(f"command envvar 'timeout' must be greater than zero, got {raw!r}")
+    return raw
+
+
 # pylint: disable=unused-argument
 def env_var_deserializer(obj_dict, cls, **kwargs):
     """convert a dict to a subclass of AbstractEnvVarConfig"""
@@ -131,6 +172,13 @@ def env_var_deserializer(obj_dict, cls, **kwargs):
         return TextEnvVarConfig(obj_dict["value"])
     if source == EnvVarSource.UNSET.value:
         return UnsetEnvVarConfig()
+    if source == EnvVarSource.COMMAND.value:
+        if "command" not in obj_dict:
+            raise KeyError("command envvar requires 'command'")
+        return CommandEnvVarConfig(
+            command=_parse_command_args(obj_dict["command"]),
+            timeout=_parse_timeout(obj_dict.get("timeout", DEFAULT_COMMAND_TIMEOUT)),
+        )
     raise RuntimeError("Invalid Source")
 
 

--- a/terrawrap/utils/config.py
+++ b/terrawrap/utils/config.py
@@ -1,6 +1,8 @@
 """Holds config utilities"""
 
+import functools
 import os
+import subprocess
 import sys
 from typing import Dict, List, Optional, Tuple
 
@@ -9,10 +11,11 @@ import networkx
 import yaml
 from jsons import DeserializationError
 
-from terrawrap.exceptions import NoDependency, NotTerraformConfigDirectory
+from terrawrap.exceptions import EnvVarResolutionError, NoDependency, NotTerraformConfigDirectory
 from terrawrap.models.wrapper_config import (
     AbstractEnvVarConfig,
     BackendsConfig,
+    CommandEnvVarConfig,
     SSMEnvVarConfig,
     TextEnvVarConfig,
     UnsetEnvVarConfig,
@@ -260,6 +263,53 @@ def graph_wrapper_dependencies(config_dir: str, config_dict, graph: networkx.DiG
         graph_wrapper_dependencies(predecessor, config_dict, graph, visited)
 
 
+@functools.lru_cache(maxsize=1)
+def _repo_root() -> str:
+    """Absolute path to the root of the git repo terrawrap was invoked from."""
+    try:
+        byte_output = subprocess.check_output(["git", "rev-parse", "--show-toplevel"], stderr=subprocess.PIPE)
+    except (subprocess.CalledProcessError, OSError) as exception:
+        raise EnvVarResolutionError(
+            "Could not determine the git repo root, which 'command' envvars run from. Are we in a git repo?"
+        ) from exception
+    return byte_output.decode("utf-8", errors="replace").strip()
+
+
+def _resolve_command(envvar_name: str, envvar_config: CommandEnvVarConfig) -> str:
+    """
+    Runs a 'command' envvar's command and returns its stdout as the envvar value. Commands run from the
+    repo root so they can be written relative to it regardless of which config directory terrawrap was
+    pointed at.
+    :param envvar_name: The name of the environment variable, used for error messages.
+    :param envvar_config: The 'command' envvar config to resolve.
+    :return: The command's stdout, stripped of surrounding whitespace.
+    """
+    try:
+        completed = subprocess.run(
+            envvar_config.command,
+            capture_output=True,
+            check=True,
+            cwd=_repo_root(),
+            timeout=envvar_config.timeout,
+        )
+    except subprocess.CalledProcessError as exception:
+        stderr = exception.stderr.decode("utf-8", errors="replace").strip()
+        raise EnvVarResolutionError(
+            f"Command for envvar {envvar_name} exited {exception.returncode}: "
+            f"{envvar_config.command}\n{stderr}"
+        ) from exception
+    except subprocess.TimeoutExpired as exception:
+        raise EnvVarResolutionError(
+            f"Command for envvar {envvar_name} timed out after {envvar_config.timeout}s: "
+            f"{envvar_config.command}"
+        ) from exception
+    except OSError as exception:
+        raise EnvVarResolutionError(
+            f"Command for envvar {envvar_name} could not be run: {envvar_config.command}"
+        ) from exception
+    return completed.stdout.decode("utf-8", errors="replace").strip()
+
+
 def resolve_envvars(envvar_configs: Dict[str, AbstractEnvVarConfig]) -> Dict[str, Optional[str]]:
     """
     Resolves the 'envvars' section from the wrapper config to actual environment variables that can be easily
@@ -276,6 +326,8 @@ def resolve_envvars(envvar_configs: Dict[str, AbstractEnvVarConfig]) -> Dict[str
             resolved_envvars[envvar_name] = str(envvar_config.value)
         if isinstance(envvar_config, UnsetEnvVarConfig):
             resolved_envvars[envvar_name] = None
+        if isinstance(envvar_config, CommandEnvVarConfig):
+            resolved_envvars[envvar_name] = _resolve_command(envvar_name, envvar_config)
     return resolved_envvars
 
 

--- a/terrawrap/utils/config.py
+++ b/terrawrap/utils/config.py
@@ -263,25 +263,38 @@ def graph_wrapper_dependencies(config_dir: str, config_dict, graph: networkx.DiG
         graph_wrapper_dependencies(predecessor, config_dict, graph, visited)
 
 
-@functools.lru_cache(maxsize=1)
-def _repo_root() -> str:
-    """Absolute path to the root of the git repo terrawrap was invoked from."""
+@functools.lru_cache(maxsize=None)
+def _repo_root(config_dir: Optional[str] = None) -> str:
+    """
+    Finds the root of the git repo holding the given config directory. Resolving from the config directory
+    rather than the process working directory keeps 'command' envvars working when terrawrap is invoked from
+    outside the checkout it was pointed at.
+    :param config_dir: The Terraform config directory being operated on. Falls back to the process working
+    directory when not given.
+    :return: The absolute path to the root of the git repo.
+    """
     try:
-        byte_output = subprocess.check_output(["git", "rev-parse", "--show-toplevel"], stderr=subprocess.PIPE)
+        byte_output = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"], cwd=config_dir, stderr=subprocess.PIPE
+        )
     except (subprocess.CalledProcessError, OSError) as exception:
         raise EnvVarResolutionError(
-            "Could not determine the git repo root, which 'command' envvars run from. Are we in a git repo?"
+            f"Could not determine the git repo root for {config_dir or os.getcwd()}, which 'command' "
+            "envvars run from. Is it in a git repo?"
         ) from exception
     return byte_output.decode("utf-8", errors="replace").strip()
 
 
-def _resolve_command(envvar_name: str, envvar_config: CommandEnvVarConfig) -> str:
+def _resolve_command(
+    envvar_name: str, envvar_config: CommandEnvVarConfig, config_dir: Optional[str] = None
+) -> str:
     """
     Runs a 'command' envvar's command and returns its stdout as the envvar value. Commands run from the
     repo root so they can be written relative to it regardless of which config directory terrawrap was
     pointed at.
     :param envvar_name: The name of the environment variable, used for error messages.
     :param envvar_config: The 'command' envvar config to resolve.
+    :param config_dir: The Terraform config directory being operated on, used to locate the repo root.
     :return: The command's stdout, stripped of surrounding whitespace.
     """
     try:
@@ -289,7 +302,7 @@ def _resolve_command(envvar_name: str, envvar_config: CommandEnvVarConfig) -> st
             envvar_config.command,
             capture_output=True,
             check=True,
-            cwd=_repo_root(),
+            cwd=_repo_root(config_dir),
             timeout=envvar_config.timeout,
         )
     except subprocess.CalledProcessError as exception:
@@ -310,11 +323,15 @@ def _resolve_command(envvar_name: str, envvar_config: CommandEnvVarConfig) -> st
     return completed.stdout.decode("utf-8", errors="replace").strip()
 
 
-def resolve_envvars(envvar_configs: Dict[str, AbstractEnvVarConfig]) -> Dict[str, Optional[str]]:
+def resolve_envvars(
+    envvar_configs: Dict[str, AbstractEnvVarConfig], config_dir: Optional[str] = None
+) -> Dict[str, Optional[str]]:
     """
     Resolves the 'envvars' section from the wrapper config to actual environment variables that can be easily
     supplied to a command.
     :param envvar_configs: The 'envvars' dictionary from the wrapper config.
+    :param config_dir: The Terraform config directory the envvars were gathered for. Only used by 'command'
+    envvars, to locate the repo root they run from.
     :return: A dictionary representing the environment variables that were resolved, with the key being the
     name of the environment variable and the value being the value of the environment variable.
     """
@@ -327,7 +344,7 @@ def resolve_envvars(envvar_configs: Dict[str, AbstractEnvVarConfig]) -> Dict[str
         if isinstance(envvar_config, UnsetEnvVarConfig):
             resolved_envvars[envvar_name] = None
         if isinstance(envvar_config, CommandEnvVarConfig):
-            resolved_envvars[envvar_name] = _resolve_command(envvar_name, envvar_config)
+            resolved_envvars[envvar_name] = _resolve_command(envvar_name, envvar_config, config_dir)
     return resolved_envvars
 
 

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.11.4"
+__version__ = "0.12.0"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -9,11 +9,15 @@ from unittest.mock import patch
 
 import networkx
 
+from terrawrap.exceptions import EnvVarResolutionError
 from terrawrap.models.wrapper_config import (
+    DEFAULT_COMMAND_TIMEOUT,
     BackendsConfig,
+    CommandEnvVarConfig,
     S3BackendConfig,
     SSMEnvVarConfig,
     WrapperConfig,
+    env_var_deserializer,
 )
 from terrawrap.utils.config import (
     calc_backend_config,
@@ -516,3 +520,111 @@ class TestSiblingIsolation(TestCase):
         enterprise_wrapper = os.path.join(self.tmpdir, "github", "amplify-enterprise", ".tf_wrapper")
         self.assertIn(github_wrapper, files)
         self.assertNotIn(enterprise_wrapper, files)
+
+
+class TestCommandEnvVarSource(TestCase):
+    """Verify the `command` envvar source parses, resolves, and fails loudly."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="terrawrap_command_")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write(self, rel_path: str, body: str) -> str:
+        abs_path = os.path.join(self.tmpdir, rel_path)
+        os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+        with open(abs_path, "w", encoding="utf-8") as handle:
+            handle.write(textwrap.dedent(body).lstrip())
+        return abs_path
+
+    def test_command_resolves_to_stdout(self):
+        """A `command` envvar resolves to the command's stdout."""
+        wrapper = self._write(
+            "config/.tf_wrapper",
+            """
+            envvars:
+              MY_TOKEN:
+                source: command
+                command: ["echo", "resolved-value"]
+            """,
+        )
+
+        config = parse_wrapper_configs([wrapper])
+        envvar = config.envvars["MY_TOKEN"]
+        self.assertIsInstance(envvar, CommandEnvVarConfig)
+        self.assertEqual(["echo", "resolved-value"], envvar.command)
+        self.assertEqual(DEFAULT_COMMAND_TIMEOUT, envvar.timeout)
+
+        self.assertEqual({"MY_TOKEN": "resolved-value"}, resolve_envvars(config.envvars))
+
+    def test_surrounding_whitespace_is_stripped(self):
+        """Trailing newlines from a command must not leak into the envvar value."""
+        resolved = resolve_envvars({"PADDED": CommandEnvVarConfig(["printf", "  padded  "])})
+
+        self.assertEqual({"PADDED": "padded"}, resolved)
+
+    def test_explicit_timeout_is_parsed(self):
+        """An explicit `timeout` overrides the default."""
+        wrapper = self._write(
+            "config/.tf_wrapper",
+            """
+            envvars:
+              MY_TOKEN:
+                source: command
+                command: ["echo", "hi"]
+                timeout: 5
+            """,
+        )
+
+        config = parse_wrapper_configs([wrapper])
+
+        self.assertEqual(5, config.envvars["MY_TOKEN"].timeout)
+
+    def test_string_command_is_rejected(self):
+        """A bare string would be mis-parsed without a shell, so reject it outright."""
+        with self.assertRaises(TypeError):
+            env_var_deserializer({"source": "command", "command": "echo hi"}, CommandEnvVarConfig)
+
+    def test_empty_command_is_rejected(self):
+        with self.assertRaises(ValueError):
+            env_var_deserializer({"source": "command", "command": []}, CommandEnvVarConfig)
+
+    def test_missing_command_key_is_rejected(self):
+        with self.assertRaises(KeyError):
+            env_var_deserializer({"source": "command"}, CommandEnvVarConfig)
+
+    def test_non_integer_timeout_is_rejected(self):
+        with self.assertRaises(TypeError):
+            env_var_deserializer(
+                {"source": "command", "command": ["echo"], "timeout": "30"}, CommandEnvVarConfig
+            )
+
+    def test_zero_timeout_is_rejected(self):
+        with self.assertRaises(ValueError):
+            env_var_deserializer(
+                {"source": "command", "command": ["echo"], "timeout": 0}, CommandEnvVarConfig
+            )
+
+    def test_failing_command_raises_with_stderr(self):
+        """A non-zero exit must fail loudly, not resolve to an empty value."""
+        command = ["sh", "-c", "echo 'boom' >&2; exit 3"]
+
+        with self.assertRaises(EnvVarResolutionError) as context:
+            resolve_envvars({"MY_TOKEN": CommandEnvVarConfig(command)})
+
+        self.assertIn("MY_TOKEN", str(context.exception))
+        self.assertIn("exited 3", str(context.exception))
+        self.assertIn("boom", str(context.exception))
+
+    def test_timed_out_command_raises(self):
+        with self.assertRaises(EnvVarResolutionError) as context:
+            resolve_envvars({"MY_TOKEN": CommandEnvVarConfig(["sleep", "10"], timeout=1)})
+
+        self.assertIn("timed out after 1s", str(context.exception))
+
+    def test_missing_binary_raises(self):
+        with self.assertRaises(EnvVarResolutionError) as context:
+            resolve_envvars({"MY_TOKEN": CommandEnvVarConfig(["terrawrap-no-such-binary-b3f1a2"])})
+
+        self.assertIn("could not be run", str(context.exception))

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -558,6 +558,25 @@ class TestCommandEnvVarSource(TestCase):
 
         self.assertEqual({"MY_TOKEN": "resolved-value"}, resolve_envvars(config.envvars))
 
+    def test_command_runs_from_the_config_dirs_repo_root(self):
+        """The repo root comes from the config directory, not the process working directory."""
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        config_dir = os.path.dirname(os.path.abspath(__file__))
+        original_cwd = os.getcwd()
+        os.chdir(self.tmpdir)
+        try:
+            resolved = resolve_envvars({"CWD": CommandEnvVarConfig(["pwd"])}, config_dir)
+        finally:
+            os.chdir(original_cwd)
+
+        self.assertEqual({"CWD": repo_root}, resolved)
+
+    def test_config_dir_outside_a_git_repo_raises(self):
+        with self.assertRaises(EnvVarResolutionError) as context:
+            resolve_envvars({"CWD": CommandEnvVarConfig(["pwd"])}, self.tmpdir)
+
+        self.assertIn("Could not determine the git repo root", str(context.exception))
+
     def test_surrounding_whitespace_is_stripped(self):
         """Trailing newlines from a command must not leak into the envvar value."""
         resolved = resolve_envvars({"PADDED": CommandEnvVarConfig(["printf", "  padded  "])})


### PR DESCRIPTION
## Why

Every existing `.tf_wrapper` envvar source can only hand back a value that **already exists somewhere**: `ssm` reads a stored parameter, `text` inlines a literal, `unset` removes one. That forces any credential terrawrap needs to be stored at rest — even when the credential could be minted per run from the caller's existing IAM identity.

The concrete driver is Consul ACLs. We want Terraform to manage Consul config entries, which means `CONSUL_HTTP_TOKEN` has to be present for both `plan` and `apply`, on laptops and in CI. The options today are a long-lived shared token in SSM (what we're trying to avoid) or a manual `export` step before every `tf` invocation that humans will forget and that has to be wired separately into the plan-check action and the apply entrypoint.

A `command` source collapses all of that into one config line that works identically on every surface.

## What

New `command` envvar source. The named command runs and its stdout, stripped of surrounding whitespace, becomes the value:

```yaml
envvars:
  CONSUL_HTTP_TOKEN:
    source: command
    command: ["clis/consul_login.py", "--print-token"]
    timeout: 60
```

Design decisions worth reviewing:

- **Argument vector, not a string.** Commands run without a shell. A string `command` is rejected outright rather than split, because accepting one would silently mis-parse quoting, pipes, and redirection.
- **Commands run from the repo root holding the config directory.** `resolve_envvars` receives the *merged* envvar configs and has no idea which `.tf_wrapper` in the inherited chain defined a given entry, so resolving relative to the defining file would mean threading that provenance through. Repo-root is unambiguous and matches how people write paths like `clis/foo.py`. The root is located from the config directory being operated on (not the process working directory), so it stays correct when terrawrap is invoked from outside the checkout — `resolve_envvars` takes an optional `config_dir` that `GraphEntry` and `PipelineEntry` already had on hand.
- **Failure is always loud.** A non-zero exit (with stderr included), a timeout (default 30s, configurable), or an unrunnable command raises `EnvVarResolutionError` naming the envvar. The trap this avoids is capturing stdout and returning `""` on failure, which would surface much later as a confusing auth error.
- **The child inherits the environment**, so `AWS_PROFILE` / `AWS_REGION` flow through to the command.

## Security

This looks like it introduces arbitrary code execution from repo content, but it doesn't widen the existing threat model. terraform-config already executes arbitrary scripts at plan time through `data "external"` — `modules/aws/functions/get_param_store_value/v1` shells out to a bash script, and `terraform_apply/v3` runs `get_subnet_ids.sh` / `get_security_group_id.sh` on plan-check runners and laptops alike. Any PR can already do this through a different door. The trust boundary is unchanged: code review on the consuming repo.

## Rollout note for consumers

`env_var_deserializer` ends in `raise RuntimeError("Invalid Source")`, so **any terrawrap older than this release hard-fails** on a `.tf_wrapper` using `command`. Because wrapper files are inherited, that failure hits every directory beneath the one that declares it, not just the intended leaf.

So consumers must upgrade *before* adopting the new source. For terraform-config that means: release this → bump the `terrawrap>=0.11,<0.12` pin in `requirements.txt` → rebuild the Docker image → confirm engineers' venvs are current → only then add the `.tf_wrapper` entry.

Version is bumped `0.11.4` → `0.12.0` (minor, per semver — backward-compatible feature). Worth flagging that a `0.11.x` patch would have flowed through the existing pin automatically and eased the rollout, but that would misrepresent a new feature as a patch. Happy to be talked into it if reviewers prefer the smoother path.

## Testing

11 new tests in `TestCommandEnvVarSource` covering end-to-end parse + resolve, whitespace stripping, explicit and default timeouts, and every rejection path (string command, empty list, missing key, non-integer timeout, zero timeout) plus every failure mode (non-zero exit with stderr surfaced, timeout, missing binary).

- `pytest test/unit` — 173 passed
- `ruff check` / `ruff format --check` — clean
- `mypy terrawrap` — identical to `main` (4 pre-existing errors; only a line-number shift from the added imports)
- `bin/versionCheck.sh main true` — passes

The `mypy` pre-commit hook could not run locally: its env install fails against CodeArtifact with a 401 on expired credentials. It was verified directly instead, and CI will run the hook properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

