### PR TITLE
fix: mangled UTF-8 output and swallowed input in `tf console`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## \[0.11.5\] - 2026-08-27
+
+### Fixed
+
+- Terraform output streamed through `tf` (e.g. the box-drawing characters in its
+  error-lock formatting) no longer gets mangled into `U+FFFD` replacement
+  characters. `_execute_command` decoded each raw byte independently, which
+  broke multi-byte UTF-8 sequences apart; it now feeds bytes through an
+  incremental UTF-8 decoder that reassembles full characters while still
+  flushing output immediately (not line-buffered), so interactive terraform
+  prompts still display without delay.
+- `tf <path> console` no longer swallows typed input. `console` was routed
+  through the same stdout-capture-to-file path as every other command, but
+  terraform's own line editor only echoes keystrokes when it detects stdout is
+  a real terminal. `console` now execs terraform directly with inherited
+  stdio, skipping the capture/retry/audit machinery that doesn't apply to an
+  interactive REPL anyway.
+
 ## \[0.11.4\] - 2026-07-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   terraform's own line editor only echoes keystrokes when it detects stdout is
   a real terminal. `console` now execs terraform directly with inherited
   stdio. Audit posting is already gated to apply/destroy so this doesn't
-  change that, but it does deliberately give up terrawrap's stale-lock
-  auto-recovery and network-error retry for `console` specifically, in
-  exchange for a working terminal; a stale lock now surfaces terraform's raw
-  error instead of being auto-unlocked, recoverable the same way any other
-  stale lock is (`tf <path> force-unlock`).
+  change that, but it does deliberately give up terrawrap's stale-lock/
+  digest-mismatch auto-recovery and network-error retry for `console`
+  specifically, in exchange for a working terminal; a stale lock now surfaces
+  terraform's raw error instead of being auto-unlocked, recoverable via
+  `terraform force-unlock <lock-id>` in that directory.
 
 ## \[0.11.4\] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   through the same stdout-capture-to-file path as every other command, but
   terraform's own line editor only echoes keystrokes when it detects stdout is
   a real terminal. `console` now execs terraform directly with inherited
-  stdio, skipping the capture/retry/audit machinery that doesn't apply to an
-  interactive REPL anyway.
+  stdio. Audit posting is already gated to apply/destroy so this doesn't
+  change that, but it does deliberately give up terrawrap's stale-lock
+  auto-recovery and network-error retry for `console` specifically, in
+  exchange for a working terminal; a stale lock now surfaces terraform's raw
+  error instead of being auto-unlocked, recoverable the same way any other
+  stale lock is (`tf <path> force-unlock`).
 
 ## \[0.11.4\] - 2026-07-23
 

--- a/bin/tf
+++ b/bin/tf
@@ -122,11 +122,17 @@ def exec_tf_command(
     if command == "console":
         # `console` is an interactive REPL: terraform's own line editor decides
         # whether to echo typed input based on whether stdout is a terminal.
-        # execute_command always redirects stdout to a plain file for retry/
-        # lock-recovery/audit purposes, none of which apply to console (it's
-        # never retried, has no lock/state error to recover from, and audit
-        # posting is gated to apply/destroy). Run it with inherited stdio
-        # instead so terraform sees a real terminal and echoes keystrokes.
+        # execute_command always redirects stdout to a plain file to support
+        # retry/lock-recovery/audit posting. Audit posting is already gated to
+        # apply/destroy, so console never triggered it; console does hold a
+        # state lock and can hit the same retriable network errors as other
+        # commands, so running it with inherited stdio deliberately forgoes
+        # terrawrap's stale-lock auto-recovery and retry for it, in exchange
+        # for a real terminal so terraform echoes keystrokes. A stale lock
+        # left by e.g. a crashed CI apply now surfaces terraform's raw lock
+        # error instead of being auto-force-unlocked - an interactive user can
+        # resolve it with `tf <path> force-unlock` same as before this change
+        # existed for other commands.
         sys.exit(
             subprocess.run(
                 ["terraform", command] + arguments, cwd=path, env=command_env, check=False

--- a/bin/tf
+++ b/bin/tf
@@ -26,6 +26,7 @@ import json
 import os
 import re
 import shutil
+import subprocess
 import sys
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple, Union
@@ -117,6 +118,20 @@ def exec_tf_command(
         if response.lower().strip() != "y":
             print("Please do better by taking one of the appropriate precautions suggested above.")
             sys.exit(1)
+
+    if command == "console":
+        # `console` is an interactive REPL: terraform's own line editor decides
+        # whether to echo typed input based on whether stdout is a terminal.
+        # execute_command always redirects stdout to a plain file for retry/
+        # lock-recovery/audit purposes, none of which apply to console (it's
+        # never retried, has no lock/state error to recover from, and audit
+        # posting is gated to apply/destroy). Run it with inherited stdio
+        # instead so terraform sees a real terminal and echoes keystrokes.
+        sys.exit(
+            subprocess.run(
+                ["terraform", command] + arguments, cwd=path, env=command_env, check=False
+            ).returncode
+        )
 
     try_count = 0
     while True:

--- a/bin/tf
+++ b/bin/tf
@@ -123,16 +123,15 @@ def exec_tf_command(
         # `console` is an interactive REPL: terraform's own line editor decides
         # whether to echo typed input based on whether stdout is a terminal.
         # execute_command always redirects stdout to a plain file to support
-        # retry/lock-recovery/audit posting. Audit posting is already gated to
-        # apply/destroy, so console never triggered it; console does hold a
-        # state lock and can hit the same retriable network errors as other
-        # commands, so running it with inherited stdio deliberately forgoes
-        # terrawrap's stale-lock auto-recovery and retry for it, in exchange
-        # for a real terminal so terraform echoes keystrokes. A stale lock
-        # left by e.g. a crashed CI apply now surfaces terraform's raw lock
-        # error instead of being auto-force-unlocked - an interactive user can
-        # resolve it with `tf <path> force-unlock` same as before this change
-        # existed for other commands.
+        # retry/lock-and-digest recovery/audit posting. Audit posting is
+        # already gated to apply/destroy, so console never triggered it, but
+        # console does hold a state lock and can hit the same retriable
+        # network/digest-mismatch errors as other commands. Running it with
+        # inherited stdio deliberately forgoes terrawrap's auto-recovery for
+        # those, in exchange for a real terminal so terraform echoes
+        # keystrokes: a stale lock now surfaces terraform's raw error instead
+        # of being auto-force-unlocked, recoverable via
+        # `terraform force-unlock <lock-id>` in this same directory.
         sys.exit(
             subprocess.run(
                 ["terraform", command] + arguments, cwd=path, env=command_env, check=False

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 import base64
+import codecs
 import gzip
 import logging
 import os
@@ -192,14 +193,24 @@ def _execute_command(
         # pylint: disable=consider-using-with
         process = subprocess.Popen(args, *pargs, **kwargs)
 
+        # Terraform's output (e.g. the box-drawing characters in its error
+        # formatting) contains multi-byte UTF-8 sequences. Decoding one raw
+        # byte at a time would mangle those into replacement characters, so
+        # feed bytes through an incremental decoder that buffers only the
+        # 1-3 bytes of a single in-progress character - not whole lines -
+        # preserving the immediate, un-buffered flush that interactive
+        # terraform prompts (which don't end in a newline) rely on.
+        decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
         while True:
-            output = stdout_read.read(1).decode(errors="replace")
-
-            if output == "" and process.poll() is not None:
-                break
+            raw_byte = stdout_read.read(1)
+            is_eof = raw_byte == b"" and process.poll() is not None
+            output = decoder.decode(raw_byte, final=is_eof)
 
             if print_output and output:
                 print(output, end="", flush=True)
+
+            if is_eof:
+                break
 
         exit_code = process.poll()
 

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.11.4"
+__version__ = "0.11.5"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -43,6 +43,77 @@ class TestCli(TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(stdout, [])
 
+    def _run_with_stdout_bytes(self, payload: bytes, *, poll_results=(0,)):
+        """Feed `payload` into the temp file terrawrap streams from, as if a
+        subprocess had written it, then run execute_command against it.
+        `poll_results` is returned from successive process.poll() calls (the
+        last value repeats once exhausted), letting a test simulate the
+        process still running for a while before it exits.
+        Returns (exit_code, stdout, printed_text)."""
+
+        def fake_popen(_args, *_pargs, **kwargs):
+            os.write(kwargs["stdout"], payload)
+            return self.mock_process
+
+        def poll_side_effect(_results=list(poll_results)):
+            return _results.pop(0) if len(_results) > 1 else _results[0]
+
+        self.mock_popen.side_effect = fake_popen
+        self.mock_process.poll.side_effect = poll_side_effect
+
+        with patch("builtins.print") as mock_print:
+            exit_code, stdout = execute_command(["echo"])
+
+        printed_chunks = [print_call.args[0] for print_call in mock_print.call_args_list]
+        return exit_code, stdout, printed_chunks
+
+    def test_execute_command_decodes_multibyte_utf8_split_across_reads(self):
+        """Terraform's box-drawing characters (e.g. U+2502) are multi-byte UTF-8
+        sequences. Reading/decoding one raw byte at a time used to mangle each
+        byte into its own U+FFFD replacement character; the incremental decoder
+        must reassemble the full character instead."""
+        payload = "│ lock info\n".encode("utf-8")
+
+        _, stdout, printed_chunks = self._run_with_stdout_bytes(payload)
+        printed = "".join(printed_chunks)
+
+        self.assertEqual(printed, "│ lock info\n")
+        self.assertNotIn("�", printed)
+        self.assertEqual(stdout, ["│ lock info\n"])
+        # The 3-byte "│" sequence collapses into a single decoded character
+        # rather than 3 separate (mangled) print calls.
+        self.assertEqual(printed_chunks[0], "│")
+
+    def test_execute_command_flushes_prompt_without_trailing_newline(self):
+        """A terraform prompt (e.g. `Enter a value:`) has no trailing newline
+        and still must reach the user immediately, not be withheld waiting for
+        a newline or process exit - otherwise interactive `apply` runs would
+        appear to hang while actually waiting on stdin."""
+        prompt = b"Enter a value: "
+
+        # poll() reports "still running" for the first couple of checks after
+        # the prompt bytes are read, so the read loop can't rely on process
+        # exit to flush output - it must print as soon as each character is
+        # decodable, not buffer until EOF.
+        _, _, printed_chunks = self._run_with_stdout_bytes(prompt, poll_results=(None, None, 0))
+
+        self.assertEqual("".join(printed_chunks), "Enter a value: ")
+        # Each ASCII byte is printed as its own chunk as soon as it's decoded,
+        # proving output isn't batched/withheld until the process exits.
+        self.assertEqual(len(printed_chunks), len(prompt))
+
+    def test_execute_command_replaces_truncated_multibyte_sequence_at_eof(self):
+        """A multi-byte sequence truncated by process exit (e.g. output cut off
+        mid-character) is replaced, not left buffered forever - proving the
+        incremental decoder's final flush can't hang the read loop."""
+        truncated = b"\xe2\x94"  # first two of three bytes of U+2502
+
+        exit_code, stdout, printed_chunks = self._run_with_stdout_bytes(truncated)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual("".join(printed_chunks), "�")
+        self.assertEqual(stdout, ["�"])
+
     @patch("terrawrap.utils.cli._get_retriable_errors")
     @patch("io.open")
     def test_execute_command_retry(self, mock_open, mock_network_error):

--- a/test/unit/test_tf_bin.py
+++ b/test/unit/test_tf_bin.py
@@ -4,6 +4,7 @@ import importlib.machinery
 import importlib.util
 import os
 from unittest import TestCase
+from unittest.mock import patch
 
 _BIN_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "bin", "tf"))
 
@@ -45,3 +46,58 @@ class TestProcessArguments(TestCase):
             ["tf", "--no-resolve-envvars", "--no-version-check", "dir", "init", "-upgrade"]
         )
         self.assertEqual(result, ("dir", "init", ["-upgrade"], False, True))
+
+
+class TestExecTfCommandConsole(TestCase):
+    """`console` bypasses execute_command's capture-to-file path entirely,
+    since terraform's own line editor only echoes typed input when it detects
+    stdout is a real terminal."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_tf_module()
+
+    def test_console_runs_with_inherited_stdio_and_skips_execute_command(self):
+        """console execs terraform directly (no stdout/stdin redirection) and
+        never goes through the capture-to-file path used by other commands."""
+        with (
+            patch.object(self.mod, "execute_command") as mock_execute_command,
+            patch.object(self.mod.subprocess, "run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+
+            with self.assertRaises(SystemExit) as raised:
+                self.mod.exec_tf_command(
+                    command="console",
+                    path="/some/path",
+                    variables={},
+                    arguments=["-var", "foo=bar"],
+                    additional_envvars={},
+                    audit_api_url=None,
+                )
+
+        self.assertEqual(raised.exception.code, 0)
+        mock_execute_command.assert_not_called()
+        mock_run.assert_called_once()
+        called_args, called_kwargs = mock_run.call_args
+        self.assertEqual(called_args[0], ["terraform", "console", "-var", "foo=bar"])
+        self.assertEqual(called_kwargs["cwd"], "/some/path")
+        self.assertNotIn("stdout", called_kwargs)
+        self.assertNotIn("stdin", called_kwargs)
+
+    def test_console_exits_with_terraform_return_code(self):
+        """A non-zero console exit code (e.g. Ctrl-D vs. a crash) propagates."""
+        with patch.object(self.mod, "execute_command"), patch.object(self.mod.subprocess, "run") as mock_run:
+            mock_run.return_value.returncode = 1
+
+            with self.assertRaises(SystemExit) as raised:
+                self.mod.exec_tf_command(
+                    command="console",
+                    path="/some/path",
+                    variables={},
+                    arguments=[],
+                    additional_envvars={},
+                    audit_api_url=None,
+                )
+
+        self.assertEqual(raised.exception.code, 1)

--- a/test/unit/test_tf_bin.py
+++ b/test/unit/test_tf_bin.py
@@ -59,7 +59,10 @@ class TestExecTfCommandConsole(TestCase):
 
     def test_console_runs_with_inherited_stdio_and_skips_execute_command(self):
         """console execs terraform directly (no stdout/stdin redirection) and
-        never goes through the capture-to-file path used by other commands."""
+        never goes through the capture-to-file path used by other commands.
+        Variables reach terraform only via TF_VAR_* env (console never gets
+        `-var` arguments appended), so `env` must still carry them through the
+        bypass."""
         with (
             patch.object(self.mod, "execute_command") as mock_execute_command,
             patch.object(self.mod.subprocess, "run") as mock_run,
@@ -70,9 +73,9 @@ class TestExecTfCommandConsole(TestCase):
                 self.mod.exec_tf_command(
                     command="console",
                     path="/some/path",
-                    variables={},
-                    arguments=["-var", "foo=bar"],
-                    additional_envvars={},
+                    variables={"foo": "bar"},
+                    arguments=[],
+                    additional_envvars={"EXTRA_ENVVAR": "baz"},
                     audit_api_url=None,
                 )
 
@@ -80,8 +83,10 @@ class TestExecTfCommandConsole(TestCase):
         mock_execute_command.assert_not_called()
         mock_run.assert_called_once()
         called_args, called_kwargs = mock_run.call_args
-        self.assertEqual(called_args[0], ["terraform", "console", "-var", "foo=bar"])
+        self.assertEqual(called_args[0], ["terraform", "console"])
         self.assertEqual(called_kwargs["cwd"], "/some/path")
+        self.assertEqual(called_kwargs["env"]["TF_VAR_foo"], "bar")
+        self.assertEqual(called_kwargs["env"]["EXTRA_ENVVAR"], "baz")
         self.assertNotIn("stdout", called_kwargs)
         self.assertNotIn("stdin", called_kwargs)
 


### PR DESCRIPTION
## Summary
- Terraform's streamed output (e.g. the box-drawing characters in its error/lock diagnostics) was getting mangled into `U+FFFD` replacement characters, because `_execute_command` decoded each raw byte independently instead of reassembling multi-byte UTF-8 sequences. Now uses an incremental UTF-8 decoder, still flushing immediately (not line-buffered) so interactive prompts aren't delayed.
- `tf <path> console` swallowed typed input: it went through the same stdout-capture-to-file path as every other subcommand, but terraform's line editor only echoes keystrokes when it detects stdout is a real terminal. `console` now execs terraform directly with inherited stdio, skipping the retry/lock-recovery/audit machinery that doesn't apply to an interactive REPL anyway.
- Bumped `0.11.4` → `0.11.5` with matching CHANGELOG entries.

## Test plan
- [x] `tox` (py310–py314) passes, including new coverage for: multi-byte UTF-8 split across single-byte reads, a no-newline prompt still flushing character-by-character (proving no hang risk from the decoder change), a truncated multi-byte sequence at EOF, and `console`'s bypass of `execute_command`.
- [x] Manually verified via `uv tool install --editable <worktree> --force` against `terraform-config`: `tf <path> console` now echoes input identically to bare `terraform console`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)