### PR TITLE
fix: flag depends_on targets missing their own depends_on declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## \[0.11.6\] - 2026-08-31
+
+### Added
+
+- `tf_validate` now reports an error when a `depends_on` target's own
+  `.tf_wrapper` doesn't declare a `depends_on` key (missing file or missing
+  key). `graph_wrapper_dependencies` recurses into every `depends_on` target
+  and aborts the whole apply if that target lacks one. `tf_validate --fix`
+  now also creates the target's `.tf_wrapper` from scratch (with
+  `depends_on: []`) when it's missing entirely, previously it only
+  back-filled the key on an existing file.
+
+### Fixed
+
+- `tf_validate --fix`'s dependency resolution now tries a `depends_on` entry
+  relative to its own `.tf_wrapper`'s directory before falling back to the
+  repo root, instead of the reverse. A `../sibling`-style entry could
+  previously resolve to an unrelated directory outside the repo that
+  happened to share the sibling's name.
+
 ## \[0.11.5\] - 2026-08-27
 
 ### Fixed

--- a/bin/tf_validate
+++ b/bin/tf_validate
@@ -2,13 +2,17 @@
 """tf_validate — validate (and optionally repair) .tf_wrapper files.
 
 Walks the given directory recursively, schema-checks every .tf_wrapper, and
-prints any errors. With --fix, also prunes dead `depends_on` entries and
-back-fills `depends_on: []` on referenced targets (matches the behavior of
-the legacy scripts/check_tf_wrapper.sh in terraform-config).
+prints any errors. Every depends_on target must itself declare a depends_on
+key in its own .tf_wrapper — graph_apply aborts the whole tree otherwise — so
+a missing file or missing key on a target is reported as an error. The fix
+flag also prunes dead `depends_on` entries and back-fills `depends_on: []`
+on referenced targets, creating their .tf_wrapper if it doesn't exist
+(matches the behavior of the legacy scripts/check_tf_wrapper.sh in
+terraform-config, plus the missing-file case).
 
 Exit codes:
-    0   No schema errors and (with --fix) no files were modified.
-    1   Schema errors found, or (with --fix) one or more files were rewritten.
+    0   No schema/depends_on errors and (with --fix) no files were modified.
+    1   Errors found, or (with --fix) one or more files were rewritten.
     2   --path is not a directory.
 
 Usage:
@@ -18,9 +22,9 @@ Usage:
 Options:
     -h, --help          Show this message and exit.
     -p, --path=PATH     Repo root to walk for .tf_wrapper files. Must be the
-                        repository root (not a subdirectory) when using --fix,
-                        because depends_on entries like 'config/...' are
-                        resolved relative to this path [default: .].
+                        repository root (not a subdirectory), because
+                        depends_on entries like 'config/...' are resolved
+                        relative to this path [default: .].
     --fix               Repair fixable issues (depends_on cleanup) before
                         validating. Exits 1 when files are rewritten so CI
                         dirty-tree checks fire.

--- a/terrawrap/utils/validator.py
+++ b/terrawrap/utils/validator.py
@@ -5,11 +5,17 @@ surfaces deserialization errors with their file path. The repair step ports
 ``scripts/check_tf_wrapper.sh`` from terraform-config: it prunes dead
 ``depends_on`` entries and back-fills ``depends_on: []`` on referenced
 targets that lack one (graph_apply requires the array to exist).
+
+The completeness check catches a class of bug where ``graph_wrapper_dependencies``
+recurses into every ``depends_on`` target and aborts the whole apply if that
+target's own ``.tf_wrapper`` doesn't declare ``depends_on`` (missing file or
+missing key). ``--fix`` resolves it in advance; without ``--fix`` it's
+reported as a validation error.
 """
 
 import logging
 import os
-from typing import List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 import yaml
 from jsons import DeserializationError
@@ -56,18 +62,24 @@ def validate_schema(tf_wrapper_paths: List[str]) -> List[str]:
 def _resolve_dep(dep: str, tf_wrapper_path: str, repo_root: str) -> str:
     """Resolve a depends_on entry to an absolute path.
 
-    Tries ``dep`` relative to ``repo_root`` first; if the result is not an
-    existing directory, falls back to resolving relative to the directory that
-    contains ``tf_wrapper_path``. Handles both ``config/foo`` and ``../sibling``
-    forms without a special-case prefix check.
+    Tries ``dep`` relative to the directory that contains ``tf_wrapper_path``
+    first, since ``../sibling``-style entries are meant to be file-local; if
+    the result is not an existing directory, falls back to resolving relative
+    to ``repo_root`` for ``config/foo``-style entries. Checking file-local
+    first avoids the case where a repo-root-relative resolution of a
+    ``../``-prefixed entry coincidentally lands on an unrelated directory
+    that happens to exist (e.g. a same-named sibling checkout outside the
+    repo).
 
-    Note: this differs from ``create_wrapper_config_obj``, which resolves against
-    ``os.getcwd()`` rather than ``repo_root`` — the results only agree when
-    ``cwd == repo_root``.
+    Note: this order is the mirror of ``create_wrapper_config_obj``, which tries
+    ``os.getcwd()``-relative first and falls back to the file-local directory.
+    The two only disagree when both candidates happen to be existing
+    directories — the case this order flip exists to get right, since that's
+    exactly the coincidental-sibling-checkout scenario described above.
     """
-    abs_dep = get_absolute_path(dep, repo_root)
+    abs_dep = get_absolute_path(dep, os.path.dirname(tf_wrapper_path))
     if not os.path.isdir(abs_dep):
-        abs_dep = get_absolute_path(dep, os.path.dirname(tf_wrapper_path))
+        abs_dep = get_absolute_path(dep, repo_root)
     return abs_dep
 
 
@@ -99,15 +111,60 @@ def _prune_dead_deps(tf_path: str, data, repo_root: str, referenced_targets: Set
     return True
 
 
-def _backfill_missing_depends_on(target_dir: str) -> Optional[str]:
+def _target_status(target_wrapper: str) -> str:
+    """Classify a depends_on target's .tf_wrapper for the completeness check.
+
+    :return: one of ``"missing"`` (no file), ``"malformed"`` (file exists but
+        isn't a YAML mapping — indistinguishable from "missing" via
+        ``_load_yaml`` alone, so checked separately), ``"no_depends_on"``
+        (mapping without the key), or ``"ok"``.
+    """
+    if not os.path.isfile(target_wrapper):
+        return "missing"
+    data = _load_yaml(target_wrapper)
+    if data is None:
+        return "malformed"
+    if data.get("depends_on") is None:
+        return "no_depends_on"
+    return "ok"
+
+
+def _is_within(path: str, root: str) -> bool:
+    """True if ``path`` is ``root`` or a descendant of it, comparing realpaths."""
+    real_path = os.path.realpath(path)
+    real_root = os.path.realpath(root)
+    return real_path == real_root or real_path.startswith(real_root + os.sep)
+
+
+def _backfill_missing_depends_on(target_dir: str, repo_root: str) -> Optional[str]:
     """Add ``depends_on: []`` to a referenced target that lacks the key.
 
-    Returns the rewritten file path if a change was made, else None.
+    Creates ``target_dir/.tf_wrapper`` from scratch when it doesn't exist at
+    all (see the module docstring for the class of bug this closes). Refuses
+    to create a file outside ``repo_root``: ``_resolve_dep``
+    can resolve a ``depends_on`` entry (e.g. one with enough ``../`` segments,
+    or one that coincidentally matches a same-named directory elsewhere) to a
+    path outside the repo, and creating a file there would be a write outside
+    the checkout that a CI dirty-tree check would never catch. A malformed
+    (non-mapping) existing file is left untouched — rewriting content we can't
+    parse risks destroying it — and reported by :func:`validate_depends_on`.
+    Returns the rewritten/created file path if a change was made, else None.
     """
     target_wrapper = os.path.join(target_dir, TF_WRAP_FILE)
-    data = _load_yaml(target_wrapper)
-    if data is None or data.get("depends_on") is not None:
+    status = _target_status(target_wrapper)
+    if status in ("ok", "malformed"):
         return None
+    if status == "missing":
+        if not _is_within(target_dir, repo_root):
+            logger.warning(
+                "refusing to create %s: target resolves outside repo_root %s",
+                target_wrapper,
+                repo_root,
+            )
+            return None
+        data = {}
+    else:  # no_depends_on
+        data = _load_yaml(target_wrapper)
     data["depends_on"] = []
     _dump_yaml(target_wrapper, data)
     return target_wrapper
@@ -132,7 +189,7 @@ def fix_depends_on(tf_wrapper_paths: List[str], repo_root: str) -> List[str]:
             changed.add(tf_path)
 
     for target_dir in referenced_targets:
-        backfilled = _backfill_missing_depends_on(target_dir)
+        backfilled = _backfill_missing_depends_on(target_dir, repo_root)
         if backfilled is not None:
             changed.add(backfilled)
 
@@ -164,6 +221,49 @@ def _dump_yaml(path: str, data) -> None:
         _yaml.dump(data, handle)
 
 
+def validate_depends_on(tf_wrapper_paths: List[str], repo_root: str) -> List[str]:
+    """Check that every depends_on target declares depends_on in its own .tf_wrapper.
+
+    Errors are deduplicated per target directory (one fix location) rather than
+    per referencing file, naming one referrer for context.
+
+    :return: sorted list of human-readable error messages.
+    """
+    # target_dir -> error message naming one referencing .tf_wrapper for context
+    violations: Dict[str, str] = {}
+    for tf_path in tf_wrapper_paths:
+        data = _load_yaml(tf_path)
+        if data is None:
+            continue
+        deps = data.get("depends_on")
+        if not deps or not isinstance(deps, list):
+            continue
+        for dep in deps:
+            target_dir = _resolve_dep(dep, tf_path, repo_root)
+            if not os.path.isdir(target_dir) or target_dir in violations:
+                continue
+            target_wrapper = os.path.join(target_dir, TF_WRAP_FILE)
+            status = _target_status(target_wrapper)
+            if status == "ok":
+                continue
+            if status == "missing":
+                violations[target_dir] = (
+                    f"{tf_path}: depends_on target '{dep}' has no {target_wrapper}; "
+                    f"create it with `depends_on: []` (or run --fix)"
+                )
+            elif status == "malformed":
+                violations[target_dir] = (
+                    f"{tf_path}: depends_on target '{dep}' — {target_wrapper} "
+                    f"isn't a valid YAML mapping; add `depends_on: []` to it"
+                )
+            else:  # no_depends_on
+                violations[target_dir] = (
+                    f"{tf_path}: depends_on target '{dep}' — {target_wrapper} "
+                    f"doesn't declare a `depends_on` key; add `depends_on: []` (or run --fix)"
+                )
+    return sorted(violations.values())
+
+
 def validate_and_fix(root: str, fix: bool) -> Tuple[List[str], List[str]]:
     """High-level entry point used by ``bin/tf_validate``.
 
@@ -174,4 +274,5 @@ def validate_and_fix(root: str, fix: bool) -> Tuple[List[str], List[str]]:
     if fix:
         changed = fix_depends_on(tf_wrappers, root)
     errors = validate_schema(tf_wrappers)
+    errors.extend(validate_depends_on(tf_wrappers, root))
     return errors, changed

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.11.5"
+__version__ = "0.11.6"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_validator.py
+++ b/test/unit/test_validator.py
@@ -17,6 +17,7 @@ from terrawrap.utils.validator import (
     find_tf_wrappers,
     fix_depends_on,
     validate_and_fix,
+    validate_depends_on,
     validate_schema,
 )
 
@@ -239,6 +240,89 @@ class TestFixDependsOn(TestCase):
         consumer_yaml = self._read_yaml(os.path.join(self.config_dir, "foo/consumer/.tf_wrapper"))
         self.assertEqual(["../sibling"], consumer_yaml["depends_on"])
 
+    def test_relative_dep_prefers_file_local_over_coincidental_repo_root_match(self):
+        """A '../x' entry resolves against the file's own directory even when repo_root/x also exists.
+
+        Regression guard: resolving repo-root-relative first could silently pick an unrelated
+        directory that happens to share a name with the intended sibling.
+        """
+        self._make_dir("foo")
+        self._make_dir("foo/sibling")
+        self._make_dir("sibling")  # coincidental repo-root/sibling — must NOT be the resolved target
+        self._write_wrapper(
+            "foo/consumer",
+            """
+            depends_on:
+              - ../sibling
+            """,
+        )
+
+        fix_depends_on(find_tf_wrappers(self.tmpdir), self.tmpdir)
+
+        correct_target = os.path.join(self.config_dir, "foo/sibling", ".tf_wrapper")
+        wrong_target = os.path.join(self.config_dir, "sibling", ".tf_wrapper")
+        self.assertTrue(os.path.isfile(correct_target))
+        self.assertFalse(os.path.isfile(wrong_target))
+
+    def test_missing_target_wrapper_is_created(self):
+        """A depends_on target with no .tf_wrapper at all gets one created with depends_on: [].
+
+        Regression guard: a target directory with no .tf_wrapper broke graph_apply for the
+        whole tree (see the validator module docstring).
+        """
+        target_dir = self._make_dir("target")
+        self._write_wrapper(
+            "consumer",
+            """
+            depends_on:
+              - config/target
+            """,
+        )
+
+        changed = fix_depends_on(find_tf_wrappers(self.tmpdir), self.tmpdir)
+
+        target_wrapper = os.path.join(target_dir, ".tf_wrapper")
+        self.assertIn(os.path.realpath(target_wrapper), [os.path.realpath(p) for p in changed])
+        self.assertEqual([], self._read_yaml(target_wrapper)["depends_on"])
+
+    def test_missing_target_outside_repo_root_is_not_created(self):
+        """--fix refuses to create a .tf_wrapper for a target that resolves outside repo_root.
+
+        Regression guard: a depends_on entry with enough '../' segments (or one that
+        coincidentally matches a directory elsewhere) must never cause a write outside the repo.
+        """
+        outside_dir = tempfile.mkdtemp(prefix="terrawrap_outside_")
+        self.addCleanup(shutil.rmtree, outside_dir, ignore_errors=True)
+        self._write_wrapper(
+            "consumer",
+            f"""
+            depends_on:
+              - {outside_dir}
+            """,
+        )
+
+        changed = fix_depends_on(find_tf_wrappers(self.tmpdir), self.tmpdir)
+
+        self.assertEqual([], changed)
+        self.assertFalse(os.path.isfile(os.path.join(outside_dir, ".tf_wrapper")))
+
+    def test_malformed_target_wrapper_is_left_untouched(self):
+        """--fix does not rewrite a target .tf_wrapper that isn't a valid YAML mapping."""
+        target_wrapper = self._write_wrapper("target", "# just a comment\n")
+        self._write_wrapper(
+            "consumer",
+            """
+            depends_on:
+              - config/target
+            """,
+        )
+
+        changed = fix_depends_on(find_tf_wrappers(self.tmpdir), self.tmpdir)
+
+        self.assertEqual([], changed)
+        with open(target_wrapper, encoding="utf-8") as handle:
+            self.assertEqual("# just a comment\n", handle.read())
+
     def test_comments_are_preserved_after_rewrite(self):
         """YAML comments in a .tf_wrapper survive a --fix rewrite (ruamel round-trip)."""
         self._make_dir("real_dep")
@@ -253,6 +337,133 @@ class TestFixDependsOn(TestCase):
             raw = handle.read()
         self.assertIn("# important: managed by team-X", raw)
         self.assertEqual([], self._read_yaml(consumer)["depends_on"])
+
+
+class TestValidateDependsOn(TestCase):
+    """validate_depends_on flags depends_on targets that don't declare depends_on themselves."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="terrawrap_depcheck_")
+        self.config_dir = os.path.join(self.tmpdir, "config")
+        os.makedirs(self.config_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _make_dir(self, rel: str) -> str:
+        path = os.path.join(self.config_dir, rel)
+        os.makedirs(path, exist_ok=True)
+        return path
+
+    def _write_wrapper(self, rel: str, body: str) -> str:
+        directory = self._make_dir(rel)
+        path = os.path.join(directory, ".tf_wrapper")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(textwrap.dedent(body).lstrip())
+        return path
+
+    def test_target_missing_wrapper_is_an_error(self):
+        """A depends_on target with no .tf_wrapper at all is reported."""
+        self._make_dir("target")
+        self._write_wrapper(
+            "consumer",
+            """
+            depends_on:
+              - config/target
+            """,
+        )
+
+        errors = validate_depends_on(find_tf_wrappers(self.tmpdir), self.tmpdir)
+
+        self.assertEqual(1, len(errors))
+        self.assertIn("config/target", errors[0])
+
+    def test_target_without_depends_on_key_is_an_error(self):
+        """A depends_on target whose .tf_wrapper doesn't declare depends_on is reported."""
+        self._write_wrapper("target", "backend_check: true\n")
+        self._write_wrapper(
+            "consumer",
+            """
+            depends_on:
+              - config/target
+            """,
+        )
+
+        errors = validate_depends_on(find_tf_wrappers(self.tmpdir), self.tmpdir)
+
+        self.assertEqual(1, len(errors))
+        self.assertIn("depends_on", errors[0])
+
+    def test_malformed_target_wrapper_is_an_error(self):
+        """A depends_on target whose .tf_wrapper exists but isn't a valid YAML mapping is reported.
+
+        Regression guard: previously indistinguishable from "missing file" via _load_yaml's
+        overloaded None return, so this case was silently skipped by both branches.
+        """
+        self._write_wrapper("target", "# just a comment\n")
+        self._write_wrapper(
+            "consumer",
+            """
+            depends_on:
+              - config/target
+            """,
+        )
+
+        errors = validate_depends_on(find_tf_wrappers(self.tmpdir), self.tmpdir)
+
+        self.assertEqual(1, len(errors))
+        self.assertIn("valid YAML mapping", errors[0])
+
+    def test_compliant_target_produces_no_error(self):
+        """A target that declares depends_on (even empty) passes."""
+        self._write_wrapper("target", "depends_on: []\n")
+        self._write_wrapper(
+            "consumer",
+            """
+            depends_on:
+              - config/target
+            """,
+        )
+
+        errors = validate_depends_on(find_tf_wrappers(self.tmpdir), self.tmpdir)
+
+        self.assertEqual([], errors)
+
+    def test_dead_dependency_is_not_reported(self):
+        """A depends_on entry that doesn't resolve to any directory is out of scope for this check."""
+        self._write_wrapper(
+            "consumer",
+            """
+            depends_on:
+              - config/ghost
+            """,
+        )
+
+        errors = validate_depends_on(find_tf_wrappers(self.tmpdir), self.tmpdir)
+
+        self.assertEqual([], errors)
+
+    def test_broken_target_referenced_twice_reports_once(self):
+        """Multiple referrers to the same broken target produce a single deduplicated error."""
+        self._make_dir("target")
+        self._write_wrapper(
+            "consumer_a",
+            """
+            depends_on:
+              - config/target
+            """,
+        )
+        self._write_wrapper(
+            "consumer_b",
+            """
+            depends_on:
+              - config/target
+            """,
+        )
+
+        errors = validate_depends_on(find_tf_wrappers(self.tmpdir), self.tmpdir)
+
+        self.assertEqual(1, len(errors))
 
 
 class TestValidateAndFix(TestCase):
@@ -322,6 +533,39 @@ class TestValidateAndFix(TestCase):
         with open(consumer, encoding="utf-8") as handle:
             after = handle.read()
         self.assertEqual(before, after)
+
+    def test_missing_target_wrapper_is_an_error_without_fix(self):
+        """A depends_on target with no .tf_wrapper surfaces as an error when fix=False."""
+        self._make_dir("target")
+        self._write_wrapper(
+            "consumer",
+            """
+            depends_on:
+              - config/target
+            """,
+        )
+
+        errors, changed = validate_and_fix(self.tmpdir, fix=False)
+
+        self.assertEqual([], changed)
+        self.assertEqual(1, len(errors))
+        self.assertIn("config/target", errors[0])
+
+    def test_fix_true_resolves_the_missing_target_wrapper_case(self):
+        """--fix creates the missing target .tf_wrapper, leaving no depends_on errors behind."""
+        self._make_dir("target")
+        self._write_wrapper(
+            "consumer",
+            """
+            depends_on:
+              - config/target
+            """,
+        )
+
+        errors, changed = validate_and_fix(self.tmpdir, fix=True)
+
+        self.assertEqual([], errors)
+        self.assertEqual(1, len(changed))
 
 
 class TestTfValidateMain(TestCase):


### PR DESCRIPTION
## Summary
- `tf_validate` now errors when a `depends_on` target's own `.tf_wrapper` is missing, malformed, or lacks a `depends_on` key. `graph_wrapper_dependencies` recurses into every `depends_on` target and aborts the whole apply otherwise.
- `--fix` now also creates a missing target's `.tf_wrapper` from scratch (`depends_on: []`), guarded against ever writing outside `repo_root`, instead of only back-filling the key on an existing file.
- Fixed `_resolve_dep`'s resolution order (file-local before repo-root): a `../sibling`-style entry could resolve to an unrelated directory outside the checkout that happened to share the sibling's name.

## Test plan
- [x] `tox` (py310–py314) passes
- [x] `pre-commit` (ruff, mypy) passes
- [x] New unit tests cover: missing target wrapper, malformed target wrapper, target missing the `depends_on` key, dead dependencies, deduplication of repeated referrers, the file-local-vs-repo-root resolution order, and the outside-repo-root containment guard
- [x] Ran a full triaged multi-reviewer review (security/code/quality/test/approach/history/comment) against the diff; both MUST_FIX findings addressed

No linked Jira story — searched and found nothing relevant in scope for this size of fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)