### PR TITLE
AT-15521: dependency targets no longer need their own .tf_wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## \[0.11.6\] - 2026-08-31
+
+### Fixed
+
+- A directory listed in another directory's `depends_on` no longer needs its own
+  `.tf_wrapper` (or a `depends_on` key in it) to avoid crashing `graph_apply`/`graph_wrapper`
+  dependency-graph construction with `Cannot list a dependency without tf_wrapper dependency configuration` / `sys.exit(1)`. A dependency target with no `.tf_wrapper`, or one that
+  doesn't declare `depends_on`, is now treated as a leaf with no further dependencies of its
+  own — the directory declaring the dependency carries that responsibility, not the target.
+  `walk_and_graph_directory` also no longer double-schedules such a target: previously it
+  could land in both the ordered dependency graph and the unordered post-graph batch, causing
+  it to apply twice.
+- A `depends_on` entry pointing at a directory with no Terraform config (no `.tf` files) is
+  now skipped, with a printed message naming it, instead of silently entering the graph and
+  having `terraform init`/`apply` run against it.
+
+### Changed
+
+- A `depends_on` entry pointing at a target with `apply_automatically: false` is now a hard
+  failure (`graph_wrapper_dependencies` prints an explanation and exits) instead of either
+  auto-applying the manually-managed target (the old bug) or silently excluding it from the
+  graph. Excluding it can't actually preserve the dependent's ordering guarantee — a no-op
+  placeholder wouldn't gate anything either, since `ApplyGraph._can_be_applied` treats a
+  no-op predecessor as already satisfied — so there's no way to honor the dependency short of
+  stopping and making the author resolve it explicitly: either drop the dependency, or set
+  `apply_automatically: true` on the target.
+
 ## \[0.11.5\] - 2026-08-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   could land in both the ordered dependency graph and the unordered post-graph batch, causing
   it to apply twice.
 - A `depends_on` entry pointing at a directory with no Terraform config (no `.tf` files) is
-  now skipped, with a printed message naming it, instead of silently entering the graph and
-  having `terraform init`/`apply` run against it.
+  now excluded from the graph as a node, with a printed message naming it, instead of silently
+  entering the graph and having `terraform init`/`apply` run against it. Its own `depends_on`
+  entries, if any, are still resolved and wired directly onto the original dependent, so a
+  chain running through such a pass-through target keeps its ordering guarantee instead of
+  losing it.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,13 +27,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - A `depends_on` entry pointing at a target with `apply_automatically: false` is now a hard
-  failure (`graph_wrapper_dependencies` prints an explanation and exits) instead of either
+  failure — `graph_wrapper_dependencies` raises `ManualDependencyError` — instead of either
   auto-applying the manually-managed target (the old bug) or silently excluding it from the
   graph. Excluding it can't actually preserve the dependent's ordering guarantee — a no-op
   placeholder wouldn't gate anything either, since `ApplyGraph._can_be_applied` treats a
   no-op predecessor as already satisfied — so there's no way to honor the dependency short of
   stopping and making the author resolve it explicitly: either drop the dependency, or set
-  `apply_automatically: true` on the target.
+  `apply_automatically: true` on the target. `graph_apply` and `visualize` catch the error and
+  print it to stderr with exit code 1, rather than a bare `sys.exit(1)` deep inside a `utils/`
+  helper (which `visualize` had no handler for at all) or leaking the message onto stdout.
 
 ## \[0.11.5\] - 2026-08-27
 

--- a/bin/graph_apply
+++ b/bin/graph_apply
@@ -24,11 +24,12 @@ Options:
 """
 
 import os
+import sys
 
 import networkx
 from docopt import docopt
 
-from terrawrap.exceptions import NoDependency
+from terrawrap.exceptions import ManualDependencyError, NoDependency
 from terrawrap.models.graph import ApplyGraph
 from terrawrap.utils.config import (
     walk_and_graph_directory,
@@ -73,6 +74,9 @@ def main():
     print("Visualizing Dependencies for %s:" % config_dir)
     try:
         graph, post_graph = walk_and_graph_directory(config_dir, wrapper_config_dict)
+    except ManualDependencyError as error:
+        print(error, file=sys.stderr)
+        exit(1)
     except ValueError:
         print(
             "Terrawrap has detected no dependency information in this graph, attempting to apply all "

--- a/bin/visualize
+++ b/bin/visualize
@@ -14,10 +14,12 @@ Options:
 """
 
 import os
+import sys
 
 import networkx
 from docopt import docopt
 
+from terrawrap.exceptions import ManualDependencyError
 from terrawrap.utils.config import graph_wrapper_dependencies, walk_and_graph_directory
 from terrawrap.utils.graph import (
     find_source_nodes,
@@ -49,12 +51,16 @@ def main():
     post_graph = []
     wrapper_config_dict = {}
     print("Visualizing Dependencies for %s:" % config_dir.replace(os.getcwd(), ""))
-    if singular_dependencies:
-        graph = networkx.DiGraph()
-        visited = []
-        graph_wrapper_dependencies(config_dir, wrapper_config_dict, graph, visited)
-    else:
-        graph, post_graph = walk_and_graph_directory(config_dir, wrapper_config_dict)
+    try:
+        if singular_dependencies:
+            graph = networkx.DiGraph()
+            visited = []
+            graph_wrapper_dependencies(config_dir, wrapper_config_dict, graph, visited)
+        else:
+            graph, post_graph = walk_and_graph_directory(config_dir, wrapper_config_dict)
+    except ManualDependencyError as error:
+        print(error, file=sys.stderr)
+        exit(1)
 
     if has_cycle(graph):
         print(

--- a/terrawrap/exceptions.py
+++ b/terrawrap/exceptions.py
@@ -9,3 +9,7 @@ class NotTerraformConfigDirectory(RuntimeError):
 
 class NoDependency(Exception):
     """Error raised when processing a directory that contains .tf_wrapper config files with no dependency"""
+
+
+class ManualDependencyError(RuntimeError):
+    """Error raised when a depends_on entry targets an apply_automatically: false directory"""

--- a/terrawrap/utils/config.py
+++ b/terrawrap/utils/config.py
@@ -9,7 +9,7 @@ import networkx
 import yaml
 from jsons import DeserializationError
 
-from terrawrap.exceptions import NoDependency, NotTerraformConfigDirectory
+from terrawrap.exceptions import ManualDependencyError, NoDependency, NotTerraformConfigDirectory
 from terrawrap.models.wrapper_config import (
     AbstractEnvVarConfig,
     BackendsConfig,
@@ -230,9 +230,12 @@ def _graph_dependency(
     it from the graph would silently drop the ordering guarantee its dependents rely on, and a
     no-op placeholder wouldn't gate anything either (ApplyGraph._can_be_applied treats a no-op
     predecessor as already satisfied) — so there is no way to honor the dependency short of
-    stopping and making the author resolve it explicitly.
+    raising and making the author resolve it explicitly. Raised rather than exited here so a
+    caller (bin/graph_apply, bin/visualize) can report it as a clean, expected failure instead
+    of an uncaught SystemExit or traceback.
 
     :return: True if the dependency (or one of its own flattened dependencies) was added.
+    :raises ManualDependencyError: if the dependency has apply_automatically: false.
     """
     if seen is None:
         seen = set()
@@ -242,19 +245,18 @@ def _graph_dependency(
 
     dependency_wrapper_config_obj = _load_wrapper_config(dependency, config_dict)
     if not dependency_wrapper_config_obj.config:
-        print(f"Skipping dependency {dependency}: not a Terraform config directory")
+        print(f"Skipping dependency {dependency}: not a Terraform config directory", file=sys.stderr)
         added = False
         for transitive_dependency in dependency_wrapper_config_obj.depends_on or []:
             if _graph_dependency(transitive_dependency, config_dir, config_dict, graph, seen):
                 added = True
         return added
     if not dependency_wrapper_config_obj.apply_automatically:
-        print(
+        raise ManualDependencyError(
             f"Cannot depend on {dependency}: apply_automatically is set to False, so "
             f"{config_dir} cannot wait on it in the graph. Either remove this dependency or "
             "set apply_automatically: true on the target."
         )
-        sys.exit(1)
     graph.add_node(dependency)
     if config_dir in graph:
         graph.add_edge(dependency, config_dir)

--- a/terrawrap/utils/config.py
+++ b/terrawrap/utils/config.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 import jsons
 import networkx
@@ -209,8 +209,22 @@ def _load_wrapper_config(config_dir: str, config_dict) -> WrapperConfig:
     return wrapper_config_obj
 
 
-def _graph_dependency(dependency: str, config_dir: str, config_dict, graph: networkx.DiGraph) -> bool:
-    """Add a dependency node/edge unless the target has no Terraform config.
+def _graph_dependency(
+    dependency: str,
+    config_dir: str,
+    config_dict,
+    graph: networkx.DiGraph,
+    seen: Optional[Set[str]] = None,
+) -> bool:
+    """Add a dependency edge, transparently flattening pass-through targets.
+
+    A target with no Terraform config of its own (e.g. a directory whose .tf_wrapper exists only
+    to declare its own depends_on) is never added as a node — there's nothing to apply — but its
+    dependents still need whatever *it* depends on, so its own depends_on entries are resolved
+    recursively and wired directly onto config_dir instead, skipping the pass-through target.
+    Only the pass-through target's own depends_on is followed this way; a dependency it would
+    otherwise inherit from an ancestor .tf_wrapper is not, since that climb only happens for
+    directories that reach graph_wrapper_dependencies as a real graphed node.
 
     A dependency with apply_automatically: false is a hard failure rather than a skip: excluding
     it from the graph would silently drop the ordering guarantee its dependents rely on, and a
@@ -218,12 +232,22 @@ def _graph_dependency(dependency: str, config_dir: str, config_dict, graph: netw
     predecessor as already satisfied) — so there is no way to honor the dependency short of
     stopping and making the author resolve it explicitly.
 
-    :return: True if the dependency was added.
+    :return: True if the dependency (or one of its own flattened dependencies) was added.
     """
+    if seen is None:
+        seen = set()
+    if dependency in seen:
+        return False
+    seen.add(dependency)
+
     dependency_wrapper_config_obj = _load_wrapper_config(dependency, config_dict)
     if not dependency_wrapper_config_obj.config:
         print(f"Skipping dependency {dependency}: not a Terraform config directory")
-        return False
+        added = False
+        for transitive_dependency in dependency_wrapper_config_obj.depends_on or []:
+            if _graph_dependency(transitive_dependency, config_dir, config_dict, graph, seen):
+                added = True
+        return added
     if not dependency_wrapper_config_obj.apply_automatically:
         print(
             f"Cannot depend on {dependency}: apply_automatically is set to False, so "

--- a/terrawrap/utils/config.py
+++ b/terrawrap/utils/config.py
@@ -165,6 +165,11 @@ def walk_and_graph_directory(starting_dir: str, config_dict) -> Tuple[networkx.D
             post_graph_runs.append(root)
     directory_graph = networkx.compose_all(graph_list)
 
+    # A directory can be walked directly (and provisionally queued as a post-graph run)
+    # before being discovered as someone else's dependency target later in the walk.
+    # Once it's part of the graph it must only run there, in order, not a second time.
+    post_graph_runs = [directory for directory in post_graph_runs if directory not in directory_graph]
+
     return directory_graph, post_graph_runs
 
 
@@ -195,6 +200,43 @@ def walk_without_graph_directory(starting_dir: str) -> List[str]:
     return post_graph_runs
 
 
+def _load_wrapper_config(config_dir: str, config_dict) -> WrapperConfig:
+    """Fetch a directory's wrapper config, caching it in config_dict so each file is read once."""
+    if config_dict.get(config_dir):
+        return config_dict[config_dir]["wrapper_config"]
+    wrapper_config_obj = create_wrapper_config_obj(config_dir)
+    config_dict[config_dir] = {"wrapper_config": wrapper_config_obj}
+    return wrapper_config_obj
+
+
+def _graph_dependency(dependency: str, config_dir: str, config_dict, graph: networkx.DiGraph) -> bool:
+    """Add a dependency node/edge unless the target has no Terraform config.
+
+    A dependency with apply_automatically: false is a hard failure rather than a skip: excluding
+    it from the graph would silently drop the ordering guarantee its dependents rely on, and a
+    no-op placeholder wouldn't gate anything either (ApplyGraph._can_be_applied treats a no-op
+    predecessor as already satisfied) — so there is no way to honor the dependency short of
+    stopping and making the author resolve it explicitly.
+
+    :return: True if the dependency was added.
+    """
+    dependency_wrapper_config_obj = _load_wrapper_config(dependency, config_dict)
+    if not dependency_wrapper_config_obj.config:
+        print(f"Skipping dependency {dependency}: not a Terraform config directory")
+        return False
+    if not dependency_wrapper_config_obj.apply_automatically:
+        print(
+            f"Cannot depend on {dependency}: apply_automatically is set to False, so "
+            f"{config_dir} cannot wait on it in the graph. Either remove this dependency or "
+            "set apply_automatically: true on the target."
+        )
+        sys.exit(1)
+    graph.add_node(dependency)
+    if config_dir in graph:
+        graph.add_edge(dependency, config_dir)
+    return True
+
+
 # pylint: disable=R0912
 def graph_wrapper_dependencies(config_dir: str, config_dict, graph: networkx.DiGraph, visited: List[str]):
     """
@@ -208,38 +250,24 @@ def graph_wrapper_dependencies(config_dir: str, config_dict, graph: networkx.DiG
         return
     visited.append(config_dir)
 
-    if config_dict.get(config_dir):  # add to dictionary so we only read the file once
-        wrapper_config_obj = config_dict[config_dir].get("wrapper_config")
-    else:
-        wrapper_config_obj = create_wrapper_config_obj(config_dir)
-        config_dict[config_dir] = {"wrapper_config": wrapper_config_obj}
+    wrapper_config_obj = _load_wrapper_config(config_dir, config_dict)
 
     if wrapper_config_obj.config:
         graph.add_node(config_dir)
 
-    tf_dependencies = wrapper_config_obj.depends_on
-
-    if tf_dependencies is None:
-        print(
-            "Cannot list a dependency without tf_wrapper dependency configuration:",
-            config_dir,
-        )
-        sys.exit(1)
+    # A dependency target with no .tf_wrapper (or one without a depends_on key) has no
+    # further dependencies of its own; the burden of declaring the relationship is on the
+    # directory that depends on it, not on the target.
+    tf_dependencies = wrapper_config_obj.depends_on or []
 
     for dependency in tf_dependencies:
-        graph.add_node(dependency)
-        if config_dir in graph:
-            graph.add_edge(dependency, config_dir)
+        _graph_dependency(dependency, config_dir, config_dict, graph)
 
     wrappers = find_wrapper_config_files(config_dir)
     wrappers.reverse()  # we want the closest wrapper file that gives inherited dependencies
     for wrapper in wrappers:
         wrapper_dir = os.path.dirname(wrapper)
-        if config_dict.get(wrapper_dir):  # add to dictionary so we only read the file once
-            new_wrapper_config_obj = config_dict[wrapper_dir].get("wrapper_config")
-        else:
-            new_wrapper_config_obj = create_wrapper_config_obj(wrapper_dir)
-            config_dict[wrapper_dir] = {"wrapper_config": new_wrapper_config_obj}
+        new_wrapper_config_obj = _load_wrapper_config(wrapper_dir, config_dict)
 
         if wrapper_dir == config_dir:
             continue
@@ -250,14 +278,13 @@ def graph_wrapper_dependencies(config_dir: str, config_dict, graph: networkx.DiG
                 if dependency == config_dir:
                     continue
                 added = True
-                graph.add_node(dependency)
-                if config_dir in graph:
-                    graph.add_edge(dependency, config_dir)
+                _graph_dependency(dependency, config_dir, config_dict, graph)
             if added:
                 break  # we only need the closest, the recursion will handle anything higher
 
-    for predecessor in list(graph.predecessors(config_dir)):
-        graph_wrapper_dependencies(predecessor, config_dict, graph, visited)
+    if config_dir in graph:
+        for predecessor in list(graph.predecessors(config_dir)):
+            graph_wrapper_dependencies(predecessor, config_dict, graph, visited)
 
 
 def resolve_envvars(envvar_configs: Dict[str, AbstractEnvVarConfig]) -> Dict[str, Optional[str]]:

--- a/terrawrap/utils/validator.py
+++ b/terrawrap/utils/validator.py
@@ -7,12 +7,20 @@ surfaces deserialization errors with their file path. The repair step ports
 targets that lack one.
 
 A missing ``depends_on`` and an explicit ``depends_on: []`` are not fully
-equivalent: as a *dependency target* (``graph_wrapper_dependencies``), both
-are a leaf with no further dependencies. But a directory walked directly
-with a missing ``depends_on`` is scheduled in the unordered post-graph batch
-instead of the ordered dependency graph (``walk_and_graph_directory``), so
-the back-fill still changes scheduling and inherited-dependency resolution
-for directories nobody else's ``depends_on`` references.
+equivalent: as a *dependency target* with Terraform config of its own
+(``graph_wrapper_dependencies``), both are a leaf with no further
+dependencies — this back-fill has no effect on a target's own dependency
+resolution. A target with no ``.tf`` files is a separate case the back-fill
+doesn't address: it's excluded from the graph regardless of ``depends_on``,
+though its own dependencies (if any) are still flattened onto whatever
+depends on it. But a directory walked directly with a missing ``depends_on``
+is scheduled in the unordered post-graph batch instead of the ordered
+dependency graph (``walk_and_graph_directory``), so the back-fill still
+changes scheduling and inherited-dependency resolution for directories
+nobody else's ``depends_on`` references. That scheduling effect is
+inherited from the back-fill's original purpose (graph_apply required the
+key to exist at all) rather than a scheduling knob chosen on its own
+merits — it isn't revisited here.
 """
 
 import logging

--- a/terrawrap/utils/validator.py
+++ b/terrawrap/utils/validator.py
@@ -4,7 +4,15 @@ The schema check loads each file through :func:`parse_wrapper_configs` and
 surfaces deserialization errors with their file path. The repair step ports
 ``scripts/check_tf_wrapper.sh`` from terraform-config: it prunes dead
 ``depends_on`` entries and back-fills ``depends_on: []`` on referenced
-targets that lack one (graph_apply requires the array to exist).
+targets that lack one.
+
+A missing ``depends_on`` and an explicit ``depends_on: []`` are not fully
+equivalent: as a *dependency target* (``graph_wrapper_dependencies``), both
+are a leaf with no further dependencies. But a directory walked directly
+with a missing ``depends_on`` is scheduled in the unordered post-graph batch
+instead of the ordered dependency graph (``walk_and_graph_directory``), so
+the back-fill still changes scheduling and inherited-dependency resolution
+for directories nobody else's ``depends_on`` references.
 """
 
 import logging

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.11.5"
+__version__ = "0.11.6"
 __git_hash__ = "GIT_HASH"

--- a/test/helpers/mock_graph_directory/config/account_level/regional_level_2/app4/test.tf
+++ b/test/helpers/mock_graph_directory/config/account_level/regional_level_2/app4/test.tf
@@ -1,0 +1,5 @@
+module "module_instance" {
+  source = "..\/..\/..\/..\/modules\/module1"
+
+  foo = "bar"
+}

--- a/test/helpers/mock_inherited_dependency_directory/config/.tf_wrapper
+++ b/test/helpers/mock_inherited_dependency_directory/config/.tf_wrapper
@@ -1,0 +1,2 @@
+depends_on:
+    - mock_inherited_dependency_directory/config/far_dep

--- a/test/helpers/mock_inherited_dependency_directory/config/b/.tf_wrapper
+++ b/test/helpers/mock_inherited_dependency_directory/config/b/.tf_wrapper
@@ -1,0 +1,2 @@
+depends_on:
+    - mock_inherited_dependency_directory/config/b/near_dep

--- a/test/helpers/mock_inherited_dependency_directory/config/b/c/test.tf
+++ b/test/helpers/mock_inherited_dependency_directory/config/b/c/test.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "c" {}

--- a/test/helpers/mock_inherited_dependency_directory/config/b/near_dep/.tf_wrapper
+++ b/test/helpers/mock_inherited_dependency_directory/config/b/near_dep/.tf_wrapper
@@ -1,0 +1,1 @@
+apply_automatically: true

--- a/test/helpers/mock_inherited_dependency_directory/config/far_dep/test.tf
+++ b/test/helpers/mock_inherited_dependency_directory/config/far_dep/test.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "far_dep" {}

--- a/test/helpers/mock_inherited_manual_dependency_directory/config/.tf_wrapper
+++ b/test/helpers/mock_inherited_manual_dependency_directory/config/.tf_wrapper
@@ -1,0 +1,2 @@
+depends_on:
+    - mock_inherited_manual_dependency_directory/config/manual

--- a/test/helpers/mock_inherited_manual_dependency_directory/config/child/test.tf
+++ b/test/helpers/mock_inherited_manual_dependency_directory/config/child/test.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "child" {}

--- a/test/helpers/mock_inherited_manual_dependency_directory/config/manual/.tf_wrapper
+++ b/test/helpers/mock_inherited_manual_dependency_directory/config/manual/.tf_wrapper
@@ -1,0 +1,1 @@
+apply_automatically: false

--- a/test/helpers/mock_inherited_manual_dependency_directory/config/manual/test.tf
+++ b/test/helpers/mock_inherited_manual_dependency_directory/config/manual/test.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "manual" {}

--- a/test/helpers/mock_manual_dependency_directory/config/dependent/.tf_wrapper
+++ b/test/helpers/mock_manual_dependency_directory/config/dependent/.tf_wrapper
@@ -1,0 +1,2 @@
+depends_on:
+    - mock_manual_dependency_directory/config/manual_target

--- a/test/helpers/mock_manual_dependency_directory/config/dependent/test.tf
+++ b/test/helpers/mock_manual_dependency_directory/config/dependent/test.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "dependent" {}

--- a/test/helpers/mock_manual_dependency_directory/config/manual_target/.tf_wrapper
+++ b/test/helpers/mock_manual_dependency_directory/config/manual_target/.tf_wrapper
@@ -1,0 +1,1 @@
+apply_automatically: false

--- a/test/helpers/mock_manual_dependency_directory/config/manual_target/test.tf
+++ b/test/helpers/mock_manual_dependency_directory/config/manual_target/test.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "manual_target" {}

--- a/test/helpers/mock_missing_wrapper_directory/config/app_a/.tf_wrapper
+++ b/test/helpers/mock_missing_wrapper_directory/config/app_a/.tf_wrapper
@@ -1,0 +1,4 @@
+depends_on:
+    - mock_missing_wrapper_directory/config/app_b_no_wrapper
+    - mock_missing_wrapper_directory/config/app_c_no_depends_on_key
+    - mock_missing_wrapper_directory/config/app_e_no_tf_files

--- a/test/helpers/mock_missing_wrapper_directory/config/app_a/test.tf
+++ b/test/helpers/mock_missing_wrapper_directory/config/app_a/test.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "app_a" {}

--- a/test/helpers/mock_missing_wrapper_directory/config/app_b_no_wrapper/test.tf
+++ b/test/helpers/mock_missing_wrapper_directory/config/app_b_no_wrapper/test.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "app_b" {}

--- a/test/helpers/mock_missing_wrapper_directory/config/app_c_no_depends_on_key/.tf_wrapper
+++ b/test/helpers/mock_missing_wrapper_directory/config/app_c_no_depends_on_key/.tf_wrapper
@@ -1,0 +1,1 @@
+apply_automatically: true

--- a/test/helpers/mock_missing_wrapper_directory/config/app_c_no_depends_on_key/test.tf
+++ b/test/helpers/mock_missing_wrapper_directory/config/app_c_no_depends_on_key/test.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "app_c" {}

--- a/test/helpers/mock_missing_wrapper_directory/config/app_e_no_tf_files/.tf_wrapper
+++ b/test/helpers/mock_missing_wrapper_directory/config/app_e_no_tf_files/.tf_wrapper
@@ -1,0 +1,1 @@
+apply_automatically: true

--- a/test/helpers/mock_relay_dependency_directory/config/dependent/.tf_wrapper
+++ b/test/helpers/mock_relay_dependency_directory/config/dependent/.tf_wrapper
@@ -1,0 +1,2 @@
+depends_on:
+    - mock_relay_dependency_directory/config/relay

--- a/test/helpers/mock_relay_dependency_directory/config/dependent/test.tf
+++ b/test/helpers/mock_relay_dependency_directory/config/dependent/test.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "dependent" {}

--- a/test/helpers/mock_relay_dependency_directory/config/leaf/test.tf
+++ b/test/helpers/mock_relay_dependency_directory/config/leaf/test.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "leaf" {}

--- a/test/helpers/mock_relay_dependency_directory/config/relay/.tf_wrapper
+++ b/test/helpers/mock_relay_dependency_directory/config/relay/.tf_wrapper
@@ -1,0 +1,2 @@
+depends_on:
+    - mock_relay_dependency_directory/config/leaf

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 import networkx
 
+from terrawrap.exceptions import ManualDependencyError
 from terrawrap.models.wrapper_config import (
     BackendsConfig,
     S3BackendConfig,
@@ -101,16 +102,44 @@ class TestConfig(TestCase):
     def test_manual_target_fails_loudly(self):
         """Depending on an apply_automatically: false target cannot honor the dependent's
         ordering guarantee (a no-op node wouldn't gate anything, per ApplyGraph._can_be_applied),
-        so this is a hard failure rather than a silent skip."""
+        so this is a hard failure naming both the target and the dependent, rather than a
+        silent skip."""
         actual_graph = networkx.DiGraph()
         visited = []
         current_dir = os.path.join(
             os.getcwd(),
             "mock_manual_dependency_directory/config/dependent",
         )
+        manual_target = os.path.join(
+            os.getcwd(),
+            "mock_manual_dependency_directory/config/manual_target",
+        )
 
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ManualDependencyError) as ctx:
             graph_wrapper_dependencies(current_dir, self.config_dict, actual_graph, visited)
+
+        self.assertIn(manual_target, str(ctx.exception))
+        self.assertIn(current_dir, str(ctx.exception))
+
+    def test_inherited_manual_target_fails_loudly(self):
+        """An apply_automatically: false target inherited from an ancestor's depends_on (the
+        climb at the closest-ancestor call site) fails just as loudly as one declared directly."""
+        actual_graph = networkx.DiGraph()
+        visited = []
+        current_dir = os.path.join(
+            os.getcwd(),
+            "mock_inherited_manual_dependency_directory/config/child",
+        )
+        manual_target = os.path.join(
+            os.getcwd(),
+            "mock_inherited_manual_dependency_directory/config/manual",
+        )
+
+        with self.assertRaises(ManualDependencyError) as ctx:
+            graph_wrapper_dependencies(current_dir, self.config_dict, actual_graph, visited)
+
+        self.assertIn(manual_target, str(ctx.exception))
+        self.assertIn(current_dir, str(ctx.exception))
 
     def test_closest_ancestor_stops_climb(self):
         """The closest ancestor's depends_on stops the inheritance climb even when every entry in
@@ -266,7 +295,7 @@ class TestConfig(TestCase):
         )
 
         out = io.StringIO()
-        with contextlib.redirect_stdout(out):
+        with contextlib.redirect_stderr(out):
             graph_wrapper_dependencies(current_dir, self.config_dict, actual_graph, visited)
 
         printed = out.getvalue()

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -66,8 +66,9 @@ class TestConfig(TestCase):
 
         self.assertTrue(networkx.is_isomorphic(actual_graph, expected_graph))
 
-    def test_graph_wrapper_dependencies_target_without_tf_wrapper(self):
-        """A depends_on target with no .tf_wrapper file at all is treated as a leaf, not an error"""
+    def test_dependency_target_without_wrapper(self):
+        """A depends_on target is treated as a leaf whether it has no .tf_wrapper at all (app_b),
+        a .tf_wrapper with no depends_on key (app_c), or is excluded for having no .tf files (app_e)."""
         actual_graph = networkx.DiGraph()
         visited = []
         current_dir = os.path.join(
@@ -97,7 +98,7 @@ class TestConfig(TestCase):
         self.assertTrue(actual_graph.has_edge(app_c, app_a))
         self.assertNotIn(app_e, actual_graph.nodes)
 
-    def test_graph_wrapper_dependencies_manual_target_fails_loudly(self):
+    def test_manual_target_fails_loudly(self):
         """Depending on an apply_automatically: false target cannot honor the dependent's
         ordering guarantee (a no-op node wouldn't gate anything, per ApplyGraph._can_be_applied),
         so this is a hard failure rather than a silent skip."""
@@ -111,7 +112,7 @@ class TestConfig(TestCase):
         with self.assertRaises(SystemExit):
             graph_wrapper_dependencies(current_dir, self.config_dict, actual_graph, visited)
 
-    def test_graph_wrapper_dependencies_closest_ancestor_stops_climb_even_if_not_automatic(self):
+    def test_closest_ancestor_stops_climb(self):
         """The closest ancestor's depends_on stops the inheritance climb even when every entry in
         it is excluded from the graph (here, no .tf files), so a more distant ancestor's
         dependency isn't pulled in."""
@@ -136,7 +137,7 @@ class TestConfig(TestCase):
         self.assertNotIn(near_dep, actual_graph.nodes)
         self.assertNotIn(far_dep, actual_graph.nodes)
 
-    def test_graph_wrapper_dependencies_config_dir_never_graphed(self):
+    def test_config_dir_never_graphed(self):
         """A config_dir with no .tf files and no depends_on is never added as a graph node;
         the predecessors lookup at the end must not crash (e.g. bin/visualize --singular <path>)."""
         actual_graph = networkx.DiGraph()
@@ -149,6 +150,32 @@ class TestConfig(TestCase):
         graph_wrapper_dependencies(current_dir, self.config_dict, actual_graph, visited)
 
         self.assertNotIn(current_dir, actual_graph.nodes)
+
+    def test_relay_target_flattens_through(self):
+        """A depends_on target with no .tf files but its own depends_on (a relay) is excluded
+        from the graph, but its dependency is flattened through onto the original dependent
+        instead of being dropped, which would otherwise invert apply order."""
+        actual_graph = networkx.DiGraph()
+        visited = []
+        current_dir = os.path.join(
+            os.getcwd(),
+            "mock_relay_dependency_directory/config/dependent",
+        )
+        graph_wrapper_dependencies(current_dir, self.config_dict, actual_graph, visited)
+
+        relay = os.path.join(
+            os.getcwd(),
+            "mock_relay_dependency_directory/config/relay",
+        )
+        leaf = os.path.join(
+            os.getcwd(),
+            "mock_relay_dependency_directory/config/leaf",
+        )
+
+        self.assertIn(current_dir, actual_graph.nodes)
+        self.assertIn(leaf, actual_graph.nodes)
+        self.assertNotIn(relay, actual_graph.nodes)
+        self.assertTrue(actual_graph.has_edge(leaf, current_dir))
 
     def test_walk_and_graph_directory(self):
         """Test dependency graph for a recursive dependency"""
@@ -192,7 +219,7 @@ class TestConfig(TestCase):
         self.assertTrue(app9 not in actual_graph.nodes)
         self.assertTrue(app9 not in actual_post_graph)
 
-    def test_walk_and_graph_directory_dependency_target_without_tf_wrapper(self):
+    def test_walk_dependency_without_wrapper(self):
         """A depends_on target with no .tf_wrapper (or none with a depends_on key) is graphed as a
         leaf and is not also scheduled a second time in the unordered post-graph batch."""
         starting_dir = os.path.join(os.getcwd(), "mock_missing_wrapper_directory/config")
@@ -213,7 +240,22 @@ class TestConfig(TestCase):
         self.assertNotIn(app_e, actual_graph.nodes)
         self.assertNotIn(app_e, actual_post_graph)
 
-    def test_graph_wrapper_dependencies_prints_when_excluding_a_dependency(self):
+    def test_walk_relay_target_flattens_through(self):
+        """Walking a relay chain (dependent -> relay, no .tf files -> leaf) keeps leaf in the
+        ordered graph, wired directly onto dependent, instead of dropping it into the unordered
+        post-graph batch where it could apply after dependent instead of before."""
+        starting_dir = os.path.join(os.getcwd(), "mock_relay_dependency_directory/config")
+        actual_graph, actual_post_graph = walk_and_graph_directory(starting_dir, self.config_dict)
+
+        dependent = os.path.join(os.getcwd(), "mock_relay_dependency_directory/config/dependent")
+        relay = os.path.join(os.getcwd(), "mock_relay_dependency_directory/config/relay")
+        leaf = os.path.join(os.getcwd(), "mock_relay_dependency_directory/config/leaf")
+
+        self.assertTrue(actual_graph.has_edge(leaf, dependent))
+        self.assertNotIn(relay, actual_graph.nodes)
+        self.assertNotIn(leaf, actual_post_graph)
+
+    def test_prints_when_excluding_dependency(self):
         """Excluding a depends_on target with no .tf files prints a message, so it's
         distinguishable from a dependency that was simply never declared."""
         actual_graph = networkx.DiGraph()

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -1,5 +1,7 @@
 """Test terraform config utilities"""
 
+import contextlib
+import io
 import os
 import shutil
 import tempfile
@@ -64,6 +66,90 @@ class TestConfig(TestCase):
 
         self.assertTrue(networkx.is_isomorphic(actual_graph, expected_graph))
 
+    def test_graph_wrapper_dependencies_target_without_tf_wrapper(self):
+        """A depends_on target with no .tf_wrapper file at all is treated as a leaf, not an error"""
+        actual_graph = networkx.DiGraph()
+        visited = []
+        current_dir = os.path.join(
+            os.getcwd(),
+            "mock_missing_wrapper_directory/config/app_a",
+        )
+        graph_wrapper_dependencies(current_dir, self.config_dict, actual_graph, visited)
+
+        app_a = current_dir
+        app_b = os.path.join(
+            os.getcwd(),
+            "mock_missing_wrapper_directory/config/app_b_no_wrapper",
+        )
+        app_c = os.path.join(
+            os.getcwd(),
+            "mock_missing_wrapper_directory/config/app_c_no_depends_on_key",
+        )
+        app_e = os.path.join(
+            os.getcwd(),
+            "mock_missing_wrapper_directory/config/app_e_no_tf_files",
+        )
+
+        self.assertIn(app_a, actual_graph.nodes)
+        self.assertIn(app_b, actual_graph.nodes)
+        self.assertIn(app_c, actual_graph.nodes)
+        self.assertTrue(actual_graph.has_edge(app_b, app_a))
+        self.assertTrue(actual_graph.has_edge(app_c, app_a))
+        self.assertNotIn(app_e, actual_graph.nodes)
+
+    def test_graph_wrapper_dependencies_manual_target_fails_loudly(self):
+        """Depending on an apply_automatically: false target cannot honor the dependent's
+        ordering guarantee (a no-op node wouldn't gate anything, per ApplyGraph._can_be_applied),
+        so this is a hard failure rather than a silent skip."""
+        actual_graph = networkx.DiGraph()
+        visited = []
+        current_dir = os.path.join(
+            os.getcwd(),
+            "mock_manual_dependency_directory/config/dependent",
+        )
+
+        with self.assertRaises(SystemExit):
+            graph_wrapper_dependencies(current_dir, self.config_dict, actual_graph, visited)
+
+    def test_graph_wrapper_dependencies_closest_ancestor_stops_climb_even_if_not_automatic(self):
+        """The closest ancestor's depends_on stops the inheritance climb even when every entry in
+        it is excluded from the graph (here, no .tf files), so a more distant ancestor's
+        dependency isn't pulled in."""
+        actual_graph = networkx.DiGraph()
+        visited = []
+        current_dir = os.path.join(
+            os.getcwd(),
+            "mock_inherited_dependency_directory/config/b/c",
+        )
+        graph_wrapper_dependencies(current_dir, self.config_dict, actual_graph, visited)
+
+        near_dep = os.path.join(
+            os.getcwd(),
+            "mock_inherited_dependency_directory/config/b/near_dep",
+        )
+        far_dep = os.path.join(
+            os.getcwd(),
+            "mock_inherited_dependency_directory/config/far_dep",
+        )
+
+        self.assertIn(current_dir, actual_graph.nodes)
+        self.assertNotIn(near_dep, actual_graph.nodes)
+        self.assertNotIn(far_dep, actual_graph.nodes)
+
+    def test_graph_wrapper_dependencies_config_dir_never_graphed(self):
+        """A config_dir with no .tf files and no depends_on is never added as a graph node;
+        the predecessors lookup at the end must not crash (e.g. bin/visualize --singular <path>)."""
+        actual_graph = networkx.DiGraph()
+        visited = []
+        current_dir = os.path.join(
+            os.getcwd(),
+            "mock_missing_wrapper_directory/config/app_e_no_tf_files",
+        )
+
+        graph_wrapper_dependencies(current_dir, self.config_dict, actual_graph, visited)
+
+        self.assertNotIn(current_dir, actual_graph.nodes)
+
     def test_walk_and_graph_directory(self):
         """Test dependency graph for a recursive dependency"""
         starting_dir = os.path.join(os.getcwd(), "mock_graph_directory/config/account_level/regional_level_2")
@@ -105,6 +191,44 @@ class TestConfig(TestCase):
         self.assertEqual(actual_post_graph, expected_post_graph)
         self.assertTrue(app9 not in actual_graph.nodes)
         self.assertTrue(app9 not in actual_post_graph)
+
+    def test_walk_and_graph_directory_dependency_target_without_tf_wrapper(self):
+        """A depends_on target with no .tf_wrapper (or none with a depends_on key) is graphed as a
+        leaf and is not also scheduled a second time in the unordered post-graph batch."""
+        starting_dir = os.path.join(os.getcwd(), "mock_missing_wrapper_directory/config")
+        actual_graph, actual_post_graph = walk_and_graph_directory(starting_dir, self.config_dict)
+
+        app_a = os.path.join(os.getcwd(), "mock_missing_wrapper_directory/config/app_a")
+        app_b = os.path.join(os.getcwd(), "mock_missing_wrapper_directory/config/app_b_no_wrapper")
+        app_c = os.path.join(os.getcwd(), "mock_missing_wrapper_directory/config/app_c_no_depends_on_key")
+        app_e = os.path.join(os.getcwd(), "mock_missing_wrapper_directory/config/app_e_no_tf_files")
+
+        self.assertIn(app_a, actual_graph.nodes)
+        self.assertIn(app_b, actual_graph.nodes)
+        self.assertIn(app_c, actual_graph.nodes)
+        self.assertTrue(actual_graph.has_edge(app_b, app_a))
+        self.assertTrue(actual_graph.has_edge(app_c, app_a))
+        self.assertNotIn(app_b, actual_post_graph)
+        self.assertNotIn(app_c, actual_post_graph)
+        self.assertNotIn(app_e, actual_graph.nodes)
+        self.assertNotIn(app_e, actual_post_graph)
+
+    def test_graph_wrapper_dependencies_prints_when_excluding_a_dependency(self):
+        """Excluding a depends_on target with no .tf files prints a message, so it's
+        distinguishable from a dependency that was simply never declared."""
+        actual_graph = networkx.DiGraph()
+        visited = []
+        current_dir = os.path.join(
+            os.getcwd(),
+            "mock_missing_wrapper_directory/config/app_a",
+        )
+
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            graph_wrapper_dependencies(current_dir, self.config_dict, actual_graph, visited)
+
+        printed = out.getvalue()
+        self.assertIn("app_e_no_tf_files", printed)
 
     def test_walk_without_graph_directory(self):
         """Test will find and list all config dirs if no dependency information"""

--- a/test/unit/test_graph_apply_bin.py
+++ b/test/unit/test_graph_apply_bin.py
@@ -1,0 +1,55 @@
+"""Tests for bin/graph_apply's handling of a manual (apply_automatically: false) dependency"""
+
+import importlib.machinery
+import importlib.util
+import io
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+from terrawrap.exceptions import ManualDependencyError
+
+_BIN_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "bin", "graph_apply"))
+
+
+def _load_graph_apply_module():
+    """Load bin/graph_apply (no .py extension) as a module via SourceFileLoader."""
+    loader = importlib.machinery.SourceFileLoader("graph_apply_bin", _BIN_PATH)
+    spec = importlib.util.spec_from_loader("graph_apply_bin", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+class TestManualDependencyError(TestCase):
+    """A ManualDependencyError from walk_and_graph_directory is a clean exit(1), not a traceback"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_graph_apply_module()
+
+    def test_prints_to_stderr_and_exits(self):
+        """The exception message reaches stderr and the process exits 1, without a traceback"""
+        docopt_args = {
+            "--operation": "plan",
+            "--debug": False,
+            "--print-only-changes": False,
+            "--parallel-jobs": "4",
+            "--path": os.getcwd(),
+        }
+        stderr = io.StringIO()
+        with (
+            patch.object(self.mod, "version_check"),
+            patch.object(self.mod, "docopt", return_value=docopt_args),
+            patch.object(
+                self.mod,
+                "walk_and_graph_directory",
+                side_effect=ManualDependencyError("Cannot depend on manual_target"),
+            ),
+            patch("sys.stderr", stderr),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                self.mod.main()
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("Cannot depend on manual_target", stderr.getvalue())

--- a/test/unit/test_visualize_bin.py
+++ b/test/unit/test_visualize_bin.py
@@ -1,0 +1,52 @@
+"""Tests for bin/visualize's handling of a manual (apply_automatically: false) dependency"""
+
+import importlib.machinery
+import importlib.util
+import io
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+from terrawrap.exceptions import ManualDependencyError
+
+_BIN_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "bin", "visualize"))
+
+
+def _load_visualize_module():
+    """Load bin/visualize (no .py extension) as a module via SourceFileLoader."""
+    loader = importlib.machinery.SourceFileLoader("visualize_bin", _BIN_PATH)
+    spec = importlib.util.spec_from_loader("visualize_bin", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+class TestManualDependencyError(TestCase):
+    """A ManualDependencyError from walk_and_graph_directory is a clean exit(1), not a traceback"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_visualize_module()
+
+    def test_prints_to_stderr_and_exits(self):
+        """The exception message reaches stderr and the process exits 1, without a traceback"""
+        docopt_args = {
+            "--singular": False,
+            "<path>": os.getcwd(),
+        }
+        stderr = io.StringIO()
+        with (
+            patch.object(self.mod, "version_check"),
+            patch.object(self.mod, "docopt", return_value=docopt_args),
+            patch.object(
+                self.mod,
+                "walk_and_graph_directory",
+                side_effect=ManualDependencyError("Cannot depend on manual_target"),
+            ),
+            patch("sys.stderr", stderr),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                self.mod.main()
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("Cannot depend on manual_target", stderr.getvalue())


### PR DESCRIPTION
## Summary

- A directory listed in another directory's `depends_on` used to require its own `.tf_wrapper` declaring `depends_on` (even empty), or `graph_wrapper_dependencies` crashed with `sys.exit(1)` (`Cannot list a dependency without tf_wrapper dependency configuration`). A missing declaration is now treated as a leaf with no further dependencies — the directory declaring the dependency carries that responsibility, not the target.
- A triaged multi-reviewer review of this fix surfaced and resolved several related gaps along the way (see `CHANGELOG.md` `[0.11.6]` for the full writeup):
  - `walk_and_graph_directory` no longer double-schedules such a target across both the ordered graph and the unordered post-graph batch.
  - A `depends_on` entry pointing at a directory with no `.tf` files is skipped (with a printed message) instead of entering the graph.
  - A `depends_on` entry pointing at an `apply_automatically: false` target is now a hard failure with an actionable message — excluding it silently can't actually preserve the dependent's ordering guarantee (`ApplyGraph._can_be_applied` treats a no-op predecessor as already satisfied).
  - A `config_dir` with no `.tf` files and no `depends_on` no longer crashes `graph.predecessors()` with an unhandled `networkx.NetworkXError` (reachable via `bin/visualize --singular`).

JIRA: AT-15521

## Overlap with #244 (resolved — #244 closed)

This PR originally overlapped with **#244** (`fix-tf_validate_depends_on_leaf`), which addressed the same underlying crash from the opposite direction: #244 treated a missing `depends_on` declaration on a target as something to flag and fix at the config level (`tf_validate --fix` auto-creating the missing `.tf_wrapper`), while this PR treats it as legitimate (the runtime now tolerates it). #244 is closed, so this PR's approach is the one moving forward.

## Test plan

- [x] New/updated unit tests in `test/unit/test_config.py` (TDD — written first, confirmed failing against pre-fix code)
- [x] Full `tox` (py310–py314) passes on all interpreters
- [x] `ruff check`, `ruff format`, `mypy`, `mdformat` all clean
- [x] Triaged multi-reviewer review run against the diff; all MUST_FIX findings resolved and independently re-verified
