### PR TITLE
fix: apply_automatically now covers child directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## \[0.11.8\] - 2026-09-03
+
+### Fixed
+
+- `apply_automatically: False` now covers child directories that have no `.tf_wrapper`
+  of their own. The flag was only ever read from a directory's own `.tf_wrapper`, so a
+  parent that disabled automatic applies for a subtree was silently ignored: every child
+  without its own wrapper fell through to the `is_config_directory` branch and was queued
+  for apply. `walk_and_graph_directory` and `walk_without_graph_directory` now resolve the
+  flag through the ancestor chain via the new `resolve_apply_automatically`, before the
+  has-its-own-`.tf_wrapper` branch. Only this one flag is resolved hierarchically —
+  `depends_on` and `config` stay per-directory, since `depends_on` inheritance is handled
+  separately in `graph_wrapper_dependencies` with closest-ancestor-wins semantics.
+  A child can still opt back in with an explicit `apply_automatically: True`.
+  Affects `graph_apply` and `tf_apply` only; a manual `tf <dir> apply` never consulted
+  the flag and is unchanged.
+
+  Note for consumers: a config directory nested under one that sets
+  `apply_automatically: False` stops being applied automatically once this version is
+  picked up, even if it has its own `.tf_wrapper` — unless that `.tf_wrapper` sets
+  `apply_automatically: True`. Audit such directories before upgrading.
+
 ## \[0.11.7\] - 2026-09-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ The following options are supported in `.tf_wrapper`:
 ```yaml
 configure_backend: True # If true, automatically configure Terraform backends.
 backend_check: True # If true, require this directory to have a terraform backend configured
+apply_automatically: True # If false, `graph_apply`/`tf_apply` skip this directory and everything under it.
 
 envvars:
   <NAME_OF_ENVVAR>:
@@ -146,6 +147,11 @@ envvars:
 plugins:
     <NAME_OF_PLUGIN>: <plugin url>
 ```
+
+`apply_automatically` describes a whole subtree: setting it to `False` also skips every
+nested config directory, including those with no `.tf_wrapper` of their own. A nested
+directory opts back in by setting `apply_automatically: True` in its own `.tf_wrapper`.
+Only automatic applies are affected — a manual `tf <dir> apply` never consults the flag.
 
 When `path` is a list, terrawrap tries each entry in order and uses the first
 one it can read. A path that returns `AccessDeniedException` or

--- a/terrawrap/utils/config.py
+++ b/terrawrap/utils/config.py
@@ -1,5 +1,6 @@
 """Holds config utilities"""
 
+import functools
 import os
 import sys
 from typing import Dict, List, Optional, Set, Tuple
@@ -106,6 +107,27 @@ def is_config_directory(directory: str) -> bool:
     return config
 
 
+@functools.lru_cache(maxsize=None)
+def resolve_apply_automatically(config_dir: str) -> bool:
+    """
+    Resolve ``apply_automatically`` for a directory, honoring ancestor ``.tf_wrapper`` files.
+
+    Deliberately narrower than merging the whole WrapperConfig: ``create_wrapper_config_obj``
+    stays per-directory because ``depends_on`` inheritance is handled separately (and with
+    closest-ancestor-wins semantics) in ``graph_wrapper_dependencies``, and because a directory
+    with an inherited non-None ``depends_on`` would be rerouted out of the post-graph batch and
+    would trip ``walk_without_graph_directory``'s NoDependency guard. Only this one flag needs
+    to describe a subtree, so only this one flag is resolved up the tree.
+
+    A descendant may re-enable automatic applies with an explicit ``apply_automatically: True``,
+    since later files override earlier ones in ``parse_wrapper_configs``.
+
+    :param config_dir: Directory to resolve for. Converted to an absolute path internally.
+    :return: The effective apply_automatically value (default True when unset anywhere).
+    """
+    return parse_wrapper_configs(find_wrapper_config_files(os.path.abspath(config_dir))).apply_automatically
+
+
 def create_wrapper_config_obj(config_dir, wrapper_file=None):
     """
     Given a config dir containing a tf_wrapper.
@@ -144,6 +166,10 @@ def walk_and_graph_directory(starting_dir: str, config_dict) -> Tuple[networkx.D
     graph_list = []
     post_graph_runs = []
     for root, _, files in os.walk(starting_dir):
+        # Resolved per-directory but inherited from ancestors, and evaluated before the
+        # has-its-own-.tf_wrapper branch below, so a parent can disable an entire subtree.
+        if not resolve_apply_automatically(root):
+            continue
         has_tf_wrapper = False
         for file in files:
             if file.endswith(TF_WRAP_FILE):
@@ -151,8 +177,6 @@ def walk_and_graph_directory(starting_dir: str, config_dict) -> Tuple[networkx.D
                 wrapper_file = os.path.join(root, file)
                 wrapper_config_obj = create_wrapper_config_obj(root, wrapper_file)
                 if not wrapper_config_obj.config:
-                    continue
-                if not wrapper_config_obj.apply_automatically:
                     continue
                 if wrapper_config_obj.depends_on is None:
                     post_graph_runs.append(root)
@@ -181,6 +205,8 @@ def walk_without_graph_directory(starting_dir: str) -> List[str]:
     """
     post_graph_runs = []
     for root, _, files in os.walk(starting_dir):
+        if not resolve_apply_automatically(root):
+            continue
         has_tf_wrapper = False
         for file in files:
             if file.endswith(TF_WRAP_FILE):
@@ -190,8 +216,6 @@ def walk_without_graph_directory(starting_dir: str) -> List[str]:
                 if wrapper_config_obj.depends_on is not None:
                     raise NoDependency("Discovered dependency information")
                 if not wrapper_config_obj.config:
-                    continue
-                if not wrapper_config_obj.apply_automatically:
                     continue
                 post_graph_runs.append(root)
         if not has_tf_wrapper and is_config_directory(root):

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.11.7"
+__version__ = "0.11.8"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_real_world_compat.py
+++ b/test/unit/test_real_world_compat.py
@@ -20,15 +20,19 @@ from terrawrap.models.wrapper_config import (
     UnsetEnvVarConfig,
 )
 from terrawrap.utils.config import (
+    create_wrapper_config_obj,
     find_wrapper_config_files,
     parse_wrapper_configs,
+    resolve_apply_automatically,
     resolve_envvars,
+    walk_without_graph_directory,
 )
 
 
 class _WrapperFixtureCase(TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix="terrawrap_compat_")
+        resolve_apply_automatically.cache_clear()
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir, ignore_errors=True)
@@ -328,6 +332,61 @@ class TestApplyAutomaticallyFlag(_WrapperFixtureCase):
 
         self.assertFalse(parse_wrapper_configs([with_false]).apply_automatically)
         self.assertTrue(parse_wrapper_configs([without]).apply_automatically)
+
+    def test_parent_false_covers_child_without_own_wrapper(self):
+        """A parent's apply_automatically: False disables a child that has no .tf_wrapper.
+
+        Regression test for the sandbox-templates leak: the child directory holds the .tf files
+        and no .tf_wrapper of its own, so before the fix it was queued for automatic apply with
+        the ancestor's flag never consulted.
+        """
+        self._write("config/templates/.tf_wrapper", "apply_automatically: False\n")
+        self._write("config/templates/api-gateway/main.tf", 'variable "environment" {}\n')
+
+        child = os.path.join(self.tmpdir, "config/templates/api-gateway")
+
+        self.assertFalse(resolve_apply_automatically(child))
+        self.assertEqual([], walk_without_graph_directory(os.path.join(self.tmpdir, "config")))
+
+    def test_child_wrapper_silent_on_flag_still_inherits_false(self):
+        """A child .tf_wrapper that omits apply_automatically inherits the ancestor's False.
+
+        Shape of config/aws/litco-dev/us-east-1/ci/rds/option_groups, whose .tf_wrapper declares
+        only depends_on. Such a child used to resolve to the True default and be graphed for
+        automatic apply; it now needs an explicit True to opt back in.
+        """
+        self._write(
+            "config/ci/rds/.tf_wrapper",
+            "apply_automatically: False\n",
+        )
+        self._write("config/ci/rds/main.tf", "# rds\n")
+        self._write("config/ci/rds/option_groups/.tf_wrapper", "depends_on: []\n")
+        self._write("config/ci/rds/option_groups/option_groups.tf", "# option groups\n")
+
+        child = os.path.join(self.tmpdir, "config/ci/rds/option_groups")
+
+        self.assertTrue(create_wrapper_config_obj(child).apply_automatically)
+        self.assertFalse(resolve_apply_automatically(child))
+
+    def test_child_can_opt_back_in(self):
+        """An explicit True on the child overrides an ancestor's False."""
+        self._write("config/templates/.tf_wrapper", "apply_automatically: False\n")
+        self._write("config/templates/api-gateway/main.tf", 'variable "environment" {}\n')
+        self._write("config/templates/api-gateway/.tf_wrapper", "apply_automatically: True\n")
+
+        child = os.path.join(self.tmpdir, "config/templates/api-gateway")
+
+        self.assertTrue(resolve_apply_automatically(child))
+        self.assertIn(child, walk_without_graph_directory(os.path.join(self.tmpdir, "config")))
+
+    def test_unset_anywhere_defaults_to_true(self):
+        """With no apply_automatically declared in the tree, a config dir is still queued."""
+        self._write("config/plain/main.tf", 'variable "environment" {}\n')
+
+        child = os.path.join(self.tmpdir, "config/plain")
+
+        self.assertTrue(resolve_apply_automatically(child))
+        self.assertIn(child, walk_without_graph_directory(os.path.join(self.tmpdir, "config")))
 
 
 class TestPlanCheckBackendCheckFlags(_WrapperFixtureCase):


### PR DESCRIPTION
## What was broken

`apply_automatically: False` was silently ignored for any directory that does not have its own `.tf_wrapper`.

- `create_wrapper_config_obj` builds `wrapper_files = [wrapper_file]` — a single-element list holding only that directory's own `.tf_wrapper`. `envvars`, `backends` and `plan_check` inherit through `find_wrapper_config_files`, which walks root → leaf; `apply_automatically` was only ever read off the non-inheriting path.
- In both `walk_and_graph_directory` and `walk_without_graph_directory`, the `if not wrapper_config_obj.apply_automatically: continue` check sat *inside* the `for file in files: if file.endswith(TF_WRAP_FILE):` block. A directory with no `.tf_wrapper` set `has_tf_wrapper = False` and fell through to `if not has_tf_wrapper and is_config_directory(root): post_graph_runs.append(root)` — queued for apply with the flag never consulted.
- Consequently the flag was enforced exactly where it is a no-op. `sandbox-templates/.tf_wrapper` carries `apply_automatically: False`, but that directory has zero `.tf` files, so `is_config_directory()` is False and there was never anything there to skip.

No test covered the parent→child case, and the README documented inheritance only for `auto.tfvars` and backend generation — this was an untested assumption, not deliberate design.

## The fix

New `resolve_apply_automatically(config_dir)` resolves **only this flag** through the ancestor chain, and the guard is hoisted above the has-its-own-`.tf_wrapper` branch in both walk functions.

## Why not make the whole WrapperConfig inherit

Changing `create_wrapper_config_obj` to use `find_wrapper_config_files` looks like the obvious fix and would break dependency scheduling repo-wide:

- **`depends_on` inheritance already exists, deliberately and with different semantics.** `graph_wrapper_dependencies` calls `find_wrapper_config_files` itself, reverses the list to find *the closest* ancestor supplying `depends_on`, and breaks after the first contributor. Merging ancestors upstream would double up with that.
- **It would flip `depends_on` from `None` to non-`None` for nearly every directory.** Nine account-level wrappers in terraform-config declare `depends_on`. The `if wrapper_config_obj.depends_on is None: post_graph_runs.append(root)` branch would stop firing, rerouting essentially every directory out of the unordered post-graph batch into the ordered dependency graph.
- **It would make `walk_without_graph_directory` raise almost everywhere**, via its `if wrapper_config_obj.depends_on is not None: raise NoDependency(...)` guard.

So `depends_on` and `config` stay strictly per-directory. `create_wrapper_config_obj` still builds a single-element list.

## Non-pruning / opt-back-in

`continue` skips the directory but lets `os.walk` keep descending, rather than pruning `dirnames`. Children independently resolve to `False` by inheriting from the same ancestor, so the subtree is still skipped — but a child that explicitly sets `apply_automatically: True` can opt back in. Pruning would make that override impossible.

`resolve_apply_automatically` is `lru_cache`d (`.tf_wrapper` contents don't change during a run) and `abspath`s its argument, since `find_wrapper_config_files` walks from the filesystem root.

## Scope of behavior change

**Only `bin/graph_apply` and `bin/tf_apply` change.** `bin/tf` — the human-facing CLI — never reads `apply_automatically` (`grep -rn apply_automatically bin/` → no matches), so a manual `tf <dir> apply` is unaffected by both the bug and the fix. PR-sandbox create/destroy, which invoke `tf` directly with `TF_VAR_environment` set, continue to work unchanged.

### Directories that stop being applied

In terraform-config, nine config directories are `apply_automatically=False` *only* by inheritance and will stop being applied automatically once this version is picked up:

| Directory | Intended? |
|---|---|
| `config/aws/amplify-learning-dev/sandbox-templates/{api-gateway,amplify-components,desmos-autosave-processor,desmos-classroom,polypad}` | ✅ yes |
| `config/aws/amplify-learning-dev/sandbox-templates/ai-foundations/asr-sandbox` | ✅ yes |
| `config/aws/amplify-learning-dev/sandbox-templates/research_and_measurement/em-scoring-literacy-sandbox` | ✅ yes |
| `config/aws/litco-dev/us-west-2/sandbox_templates/amplify-components` | ✅ yes |
| `config/aws/litco-dev/us-east-1/ci/rds/option_groups` | ⚠️ **probably not** |

The first eight are the leak this fixes — sandbox templates that pipelines were applying every ~30 min with no `TF_VAR_environment`, so the plan-check placeholder default in `variables.tf` became a real long-lived environment.

`option_groups` is different and needs action before this ships. Its `.tf_wrapper` declares only `depends_on: []`, so it used to resolve to the `True` default and was graphed for automatic apply; it now inherits `False` from `ci/rds`. **Remedy: add `apply_automatically: True` to `config/aws/litco-dev/us-east-1/ci/rds/option_groups/.tf_wrapper` in terraform-config before upgrading the pin.** `test_child_wrapper_silent_on_flag_still_inherits_false` locks in this shape.

## Known remaining inconsistency (not addressed here)

`_graph_dependency` reads `apply_automatically` off the per-directory `_load_wrapper_config`, so a `depends_on` target that inherits `False` from an ancestor still won't raise `ManualDependencyError`. There is exactly one such edge in terraform-config today (`ci/rds` → `ci/rds/option_groups`), and it is unreachable because `ci/rds` is itself skipped. Left alone deliberately: routing it through the resolver converts a silent pass into a hard `graph_apply` failure, which deserves its own change.

## Test plan

- Three new tests in `TestApplyAutomaticallyFlag` for parent→child, child opt-back-in, and unset-anywhere-defaults-to-True, plus one for the `option_groups` shape.
- Verified `test_parent_false_covers_child_without_own_wrapper` exercises the bug rather than just the new symbol: with `config.py` stashed, a standalone probe calling `walk_without_graph_directory` on the fixture returned `['<tmp>/config/templates/api-gateway']` (child queued for apply); with the fix it returns `[]`.
- `tox` green on py310–py314: 185 → 189 passed, no failures.
- `pre-commit` (ruff check, ruff format, mypy, mdformat) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
