### PR TITLE
Reuse credential signer + git-root lookup per run, circuit-break failed chunk POSTs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## \[0.11.8\] - 2026-09-04
+
+### Fixed
+
+- `0.11.7`'s log-chunk shipper built a fresh AWS SigV4 signer (and therefore a fresh
+  credential fetch) on every chunk POST, and a fresh `get_git_root()` subprocess fork per
+  chunk. At fleet concurrency this saturated the ECS task's container credential metadata
+  endpoint, returning `HTTP 429` and starving every other credential consumer in the same
+  task -- consistent with the 2026-09-04 fleet-wide `apply` outage (`No valid credential sources found`, `unexpected end of JSON input` from `data.external` blocks). The signer
+  and git root are now built once per URL/path and reused for the rest of the run.
+- A log-chunk POST failure now trips a circuit breaker after 3 consecutive failures,
+  disabling streaming for the remainder of the run instead of retrying every flush with
+  no backoff (previously up to ~586 doomed POSTs per apply against a broken/unreachable
+  audit API).
+
+### Changed
+
+- `CHUNK_LINE_COUNT` 10 → 100 and `CHUNK_FLUSH_INTERVAL` 5.0s → 15.0s, cutting log-chunk
+  POST volume roughly 10x.
+
 ## \[0.11.7\] - 2026-09-03
 
 ### Added

--- a/terrawrap/utils/cli.py
+++ b/terrawrap/utils/cli.py
@@ -11,7 +11,7 @@ import subprocess
 import tempfile
 import time
 from enum import Enum
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import requests
@@ -48,8 +48,48 @@ AUDIT_POST_PATH = "/audit_info"
 AUDIT_UPDATE_PATH = "/update_audit_info"
 LOG_CHUNK_POST_PATH = "/log_chunk"
 OUTPUT_COMPRESSION_THRESHOLD = 5 * 1024 * 1024
-CHUNK_LINE_COUNT = 10
-CHUNK_FLUSH_INTERVAL = 5.0
+CHUNK_LINE_COUNT = 100
+CHUNK_FLUSH_INTERVAL = 15.0
+# After this many consecutive log-chunk POST failures in a single run, stop
+# trying for the rest of it -- a broken/unreachable audit API otherwise means
+# hundreds of doomed POSTs (one per flush) with zero backoff.
+CHUNK_FAILURE_CIRCUIT_BREAKER = 3
+
+# BotoAWSRequestsAuth wraps a boto3.Session, which caches and auto-refreshes
+# credentials. Constructing a fresh one per call (previously done on every
+# audit-info/log-chunk POST) defeats that caching: each construction
+# re-resolves credentials from scratch, and at high concurrency
+# (parallel_applies) that can saturate the container credential metadata
+# endpoint (429s), which in turn starves Terraform's own credential
+# resolution in the same task. Cached per audit_api_url (host) since the
+# signing host differs per URL; effectively "once per process" since this
+# module-level cache lives for the interpreter's lifetime.
+_auth_cache: Dict[str, BotoAWSRequestsAuth] = {}
+
+
+def _get_auth(audit_api_url: str) -> BotoAWSRequestsAuth:
+    """Returns a cached BotoAWSRequestsAuth for the given audit API URL."""
+    if audit_api_url not in _auth_cache:
+        _auth_cache[audit_api_url] = BotoAWSRequestsAuth(
+            aws_host=urlparse(audit_api_url).hostname,
+            aws_region="us-west-2",
+            aws_service="execute-api",
+        )
+    return _auth_cache[audit_api_url]
+
+
+# get_git_root shells out to `git rev-parse --show-toplevel` via GitPython --
+# a subprocess fork per call. _post_log_chunk previously called it on every
+# chunk POST for a path that never changes within a single execute_command
+# run (hundreds of forks per apply at CHUNK_LINE_COUNT's old cadence).
+_git_root_cache: Dict[str, str] = {}
+
+
+def _cached_git_root(path: str) -> str:
+    """Returns a cached get_git_root(path) result."""
+    if path not in _git_root_cache:
+        _git_root_cache[path] = get_git_root(path)
+    return _git_root_cache[path]
 
 
 class Status(str, Enum):
@@ -114,9 +154,16 @@ def execute_command(
 
     should_stream = bool(audit_api_urls and kwargs["cwd"] and ("apply" in args or "destroy" in args))
     chunk_seq = 0
+    consecutive_chunk_failures = 0
+    streaming_disabled = False
 
     def _chunk_callback(content: str) -> None:
-        nonlocal chunk_seq
+        nonlocal chunk_seq, consecutive_chunk_failures, streaming_disabled
+        if streaming_disabled:
+            chunk_seq += 1
+            return
+
+        any_succeeded = False
         for url in audit_api_urls:
             try:
                 _post_log_chunk(
@@ -126,9 +173,22 @@ def execute_command(
                     sequence=chunk_seq,
                     content=content,
                 )
+                any_succeeded = True
             except Exception as exc:  # pylint: disable=broad-except
                 logger.warning("Failed to post log chunk %d to %s: %s", chunk_seq, url, exc)
         chunk_seq += 1
+
+        if any_succeeded:
+            consecutive_chunk_failures = 0
+            return
+
+        consecutive_chunk_failures += 1
+        if consecutive_chunk_failures >= CHUNK_FAILURE_CIRCUIT_BREAKER:
+            streaming_disabled = True
+            logger.warning(
+                "Disabling live log-chunk streaming for the rest of this run after %d consecutive failures",
+                consecutive_chunk_failures,
+            )
 
     jitter = Jitter()
     time_passed = 0
@@ -278,7 +338,7 @@ def _post_audit_info(
     stdout: Optional[List[str]] = None,
     update: bool = False,
 ):
-    root = get_git_root(path)
+    root = _cached_git_root(path)
     sha = get_git_hash(path)
 
     path = path.replace(root, "")
@@ -291,11 +351,7 @@ def _post_audit_info(
 
     url = (audit_api_url + AUDIT_UPDATE_PATH) if update else (audit_api_url + AUDIT_POST_PATH)
 
-    auth = BotoAWSRequestsAuth(
-        aws_host=urlparse(audit_api_url).hostname,
-        aws_region="us-west-2",
-        aws_service="execute-api",
-    )
+    auth = _get_auth(audit_api_url)
 
     stdout_str = "".join(stdout) if stdout else ""
 
@@ -346,14 +402,10 @@ def _post_log_chunk(
     content: str,
 ) -> None:
     """POST a single log chunk to the audit API during an apply."""
-    root = get_git_root(path)
+    root = _cached_git_root(path)
     directory = path.replace(root, "")
 
-    auth = BotoAWSRequestsAuth(
-        aws_host=urlparse(audit_api_url).hostname,
-        aws_region="us-west-2",
-        aws_service="execute-api",
-    )
+    auth = _get_auth(audit_api_url)
 
     response = requests.post(
         url=audit_api_url + LOG_CHUNK_POST_PATH,

--- a/terrawrap/version.py
+++ b/terrawrap/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.11.7"
+__version__ = "0.11.8"
 __git_hash__ = "GIT_HASH"

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -8,9 +8,13 @@ from unittest.mock import ANY, call, patch
 from requests.exceptions import HTTPError
 
 from terrawrap.utils.cli import (
+    CHUNK_FAILURE_CIRCUIT_BREAKER,
+    CHUNK_LINE_COUNT,
     MAX_RETRIES,
     Status,
+    _auth_cache,
     _get_retriable_errors,
+    _git_root_cache,
     _post_audit_info,
     _post_log_chunk,
     execute_command,
@@ -30,6 +34,13 @@ class TestCli(TestCase):
         self.jitter_patcher = patch("terrawrap.utils.cli.Jitter")
         self.mock_jitter = self.jitter_patcher.start()
         self.mock_jitter.return_value.backoff.return_value = 3
+
+        # Both are process-lifetime caches keyed by URL/path; several tests
+        # below reuse the same fake URLs, so a prior test's cached (mocked)
+        # auth/root would otherwise silently short-circuit a later test's
+        # real call and its assertions on it.
+        _auth_cache.clear()
+        _git_root_cache.clear()
 
     def tearDown(self):
         self.popen_patcher.stop()
@@ -314,6 +325,10 @@ class TestCli(TestCase):
 class TestPostLogChunk(TestCase):
     """Test the log-chunk POST helper"""
 
+    def setUp(self):
+        _auth_cache.clear()
+        _git_root_cache.clear()
+
     @patch("terrawrap.utils.cli.BotoAWSRequestsAuth")
     @patch("requests.post")
     def test_post_log_chunk_payload(self, mock_post, _):
@@ -387,6 +402,8 @@ class TestChunkStreaming(TestCase):
     def setUp(self):
         self.audit_info_patcher = patch("terrawrap.utils.cli._post_audit_info")
         self.audit_info_patcher.start()
+        _auth_cache.clear()
+        _git_root_cache.clear()
 
     def tearDown(self):
         self.audit_info_patcher.stop()
@@ -394,7 +411,9 @@ class TestChunkStreaming(TestCase):
     @patch("terrawrap.utils.cli._post_log_chunk")
     def test_streams_chunks_when_applying(self, mock_post_chunk):
         """Output is flushed once at the CHUNK_LINE_COUNT threshold and once more at EOF"""
-        code = "\n".join(f"print({i})" for i in range(15))
+        extra_lines = 5
+        total_lines = CHUNK_LINE_COUNT + extra_lines
+        code = "\n".join(f"print({i})" for i in range(total_lines))
         exit_code, _ = execute_command(
             ["python3", "-c", code, "apply"],
             audit_api_url="https://foo.bar",
@@ -408,8 +427,9 @@ class TestChunkStreaming(TestCase):
         self.assertEqual(sequences, [0, 1])
 
         first_chunk, second_chunk = (c.kwargs["content"] for c in mock_post_chunk.call_args_list)
-        self.assertEqual(first_chunk.count("\n"), 10)
-        self.assertEqual(second_chunk, "10\n11\n12\n13\n14\n")
+        self.assertEqual(first_chunk.count("\n"), CHUNK_LINE_COUNT)
+        expected_second_chunk = "".join(f"{i}\n" for i in range(CHUNK_LINE_COUNT, total_lines))
+        self.assertEqual(second_chunk, expected_second_chunk)
 
     @patch("terrawrap.utils.cli._post_log_chunk")
     def test_no_streaming_without_audit_api_url(self, mock_post_chunk):
@@ -450,3 +470,50 @@ class TestChunkStreaming(TestCase):
         )
 
         self.assertEqual(exit_code, 0)
+
+    @patch("terrawrap.utils.cli._post_log_chunk")
+    def test_circuit_breaker_disables_streaming_after_consecutive_failures(self, mock_post_chunk):
+        """After CHUNK_FAILURE_CIRCUIT_BREAKER consecutive failures, streaming stops
+        for the rest of the run instead of hammering a broken/unreachable audit API
+        once per flush with zero backoff (the old behavior: ~586 failed POSTs/apply)."""
+        mock_post_chunk.side_effect = Exception("boom")
+
+        total_lines = CHUNK_LINE_COUNT * (CHUNK_FAILURE_CIRCUIT_BREAKER + 3)
+        code = "\n".join(f"print({i})" for i in range(total_lines))
+
+        exit_code, _ = execute_command(
+            ["python3", "-c", code, "apply"],
+            audit_api_url="https://foo.bar",
+            cwd=os.getcwd(),
+            print_output=False,
+        )
+
+        self.assertEqual(exit_code, 0)
+        # One attempt per flush until the breaker trips, then none -- not one
+        # per remaining flush (there would be CHUNK_FAILURE_CIRCUIT_BREAKER + 3
+        # of those).
+        self.assertEqual(mock_post_chunk.call_count, CHUNK_FAILURE_CIRCUIT_BREAKER)
+
+    @patch("requests.post")
+    @patch("terrawrap.utils.cli.BotoAWSRequestsAuth")
+    def test_log_chunk_auth_constructed_once_across_many_chunks(self, mock_auth, _mock_requests_post):
+        """Regression guard for the outage: the AWS credential signer must be built
+        once per URL and reused, not once per chunk -- a fresh signer per chunk
+        re-resolves credentials from scratch every time, which at fleet concurrency
+        saturates the container credential metadata endpoint and starves Terraform's
+        own credential resolution in the same task."""
+        total_lines = CHUNK_LINE_COUNT * 3
+        code = "\n".join(f"print({i})" for i in range(total_lines))
+
+        exit_code, _ = execute_command(
+            ["python3", "-c", code, "apply"],
+            audit_api_url="https://foo.bar",
+            cwd=os.getcwd(),
+            print_output=False,
+        )
+
+        self.assertEqual(exit_code, 0)
+        # Real _post_log_chunk ran (not mocked here) and actually posted 3 chunks...
+        self.assertEqual(_mock_requests_post.call_count, 3)
+        # ...but only constructed the signer once.
+        mock_auth.assert_called_once()


### PR DESCRIPTION
## Summary
- Real fix for the 2026-09-04 fleet-wide terraform-apply outage. 0.11.7's log-chunk shipper built a fresh `BotoAWSRequestsAuth`/`boto3.Session` (and a fresh `get_git_root()` subprocess fork) on every chunk POST. At fleet concurrency this saturated the ECS task's container credential metadata endpoint (429s), starving every other credential consumer in the same task -- consistent with the observed `No valid credential sources found` / `data.external` JSON-parse failures.
- Signer and git root are now built once per URL/path and reused for the rest of the run.
- Circuit breaker: after 3 consecutive log-chunk POST failures, disable streaming for the rest of the run instead of retrying every flush with no backoff.
- `CHUNK_LINE_COUNT` 10 → 100, `CHUNK_FLUSH_INTERVAL` 5.0s → 15.0s (~10x fewer POSTs).

## Test plan
- [x] `pytest test/unit/test_cli.py` — 23/23 passing, including a new test asserting the signer is constructed once across many chunks, and a circuit-breaker test
- [ ] CI (tox matrix, this sandbox has no py3.10-3.14 interpreters to run it locally)
- [ ] After merge+publish, confirm `meta429` / `Failed to post log chunk` return to zero fleet-wide